### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/585/319/7/1125853197.geojson
+++ b/data/112/585/319/7/1125853197.geojson
@@ -497,6 +497,9 @@
     ],
     "wof:country":"KH",
     "wof:created":1497293502,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"69683eeebba7f6080dd286f1ade3e20f",
     "wof:hierarchy":[
         {
@@ -508,7 +511,7 @@
         }
     ],
     "wof:id":1125853197,
-    "wof:lastmodified":1566727528,
+    "wof:lastmodified":1582346020,
     "wof:name":"Phnom Penh",
     "wof:parent_id":1108564771,
     "wof:placetype":"locality",

--- a/data/421/168/305/421168305.geojson
+++ b/data/421/168/305/421168305.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008761,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"652d108a53f23d26e6070fc1797f2c58",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421168305,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Ta Khmau",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/169/333/421169333.geojson
+++ b/data/421/169/333/421169333.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2338360dbe3cc650629df85b77f7a88a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421169333,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kampong Svay",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/170/109/421170109.geojson
+++ b/data/421/170/109/421170109.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eccb55aa1540c751240d7b367a65085",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421170109,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Pailin",
     "wof:parent_id":85673037,
     "wof:placetype":"county",

--- a/data/421/170/329/421170329.geojson
+++ b/data/421/170/329/421170329.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008848,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75d43897a63b387428c5a1d2569fc51c",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421170329,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Serei Saophoan",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/171/409/421171409.geojson
+++ b/data/421/171/409/421171409.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008892,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef42b81007c0a7304b4190094805e997",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421171409,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Prasat Bakong",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/171/545/421171545.geojson
+++ b/data/421/171/545/421171545.geojson
@@ -260,6 +260,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f61f3bbdc4822b6d4a6abe9c619f39dc",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":421171545,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Battambang",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/172/391/421172391.geojson
+++ b/data/421/172/391/421172391.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459008939,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45c9d6ea6a85120d37ac3ff9c4356f5e",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421172391,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Aek Phnum",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/175/595/421175595.geojson
+++ b/data/421/175/595/421175595.geojson
@@ -271,6 +271,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"506c962d9415ed1a4d299d3ceb09769a",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":421175595,
-    "wof:lastmodified":1561778136,
+    "wof:lastmodified":1582346019,
     "wof:name":"Prey Veng",
     "wof:parent_id":1108564789,
     "wof:placetype":"locality",

--- a/data/421/177/919/421177919.geojson
+++ b/data/421/177/919/421177919.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98911d0c1b7e463ef8240a978710c35b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421177919,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Ou Reang Ov",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/177/965/421177965.geojson
+++ b/data/421/177/965/421177965.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009166,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97623f38957c8acc4f24a80ef7c4199c",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421177965,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Odongk",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/421/180/491/421180491.geojson
+++ b/data/421/180/491/421180491.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009261,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"444f7a28ecca7011494e181e5d9a16a0",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421180491,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Stueng Saen",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/181/961/421181961.geojson
+++ b/data/421/181/961/421181961.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009314,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b485451fade13e19fb0025b84edda29a",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421181961,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Svay Chek",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/182/521/421182521.geojson
+++ b/data/421/182/521/421182521.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009333,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60e7c733d8785236a3710bba9684ab06",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421182521,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Prasat Sambour",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/183/117/421183117.geojson
+++ b/data/421/183/117/421183117.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009358,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ce584cecea14b876844b655754365f9",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421183117,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Srae Ambel",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/183/889/421183889.geojson
+++ b/data/421/183/889/421183889.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009390,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"397a1fd7ed97970150b8e6d71c80177f",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421183889,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Ponhea Kraek",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/183/891/421183891.geojson
+++ b/data/421/183/891/421183891.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009391,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2cf19effdfdb8af38cb527900c27147",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421183891,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Tboung Khmum",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/183/973/421183973.geojson
+++ b/data/421/183/973/421183973.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ab59aab772c03734db7957a44ea01b6",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421183973,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Preah Netr Preah",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/184/153/421184153.geojson
+++ b/data/421/184/153/421184153.geojson
@@ -271,6 +271,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"65a2d215373024b407891ffd72878caf",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":421184153,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346020,
     "wof:name":"Stoeng Treng",
     "wof:parent_id":421200835,
     "wof:placetype":"locality",

--- a/data/421/185/341/421185341.geojson
+++ b/data/421/185/341/421185341.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f61741506f3b0ac1e82737c2c740a90",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421185341,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Ban Lung",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/185/505/421185505.geojson
+++ b/data/421/185/505/421185505.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009445,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5fb95a2047efa73831eeaeaab28984ab",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421185505,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Puok",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/187/975/421187975.geojson
+++ b/data/421/187/975/421187975.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d677dec8377c3a284897fc643dafea23",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421187975,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346018,
     "wof:name":"Chhaeb",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/421/187/977/421187977.geojson
+++ b/data/421/187/977/421187977.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0972a37b47decc722e0b3e523add6f5",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421187977,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Doun Kaev",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/421/188/047/421188047.geojson
+++ b/data/421/188/047/421188047.geojson
@@ -281,6 +281,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b050dc360df7dd1aa86b9f556763ce8",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":421188047,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346018,
     "wof:name":"Sandan",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/188/049/421188049.geojson
+++ b/data/421/188/049/421188049.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e44fec058a6fa4f84720684b97314cf",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421188049,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kracheh",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/421/188/051/421188051.geojson
+++ b/data/421/188/051/421188051.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca119f2b710d92a434c9a16832b9bbfd",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421188051,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Sambour",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/421/188/053/421188053.geojson
+++ b/data/421/188/053/421188053.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a7404fa177da588928aef0b261b859d",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421188053,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346019,
     "wof:name":"Ta Veaeng",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/188/055/421188055.geojson
+++ b/data/421/188/055/421188055.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8556de76b5390698ce6619b2b08be822",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421188055,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346019,
     "wof:name":"Saen Monourom",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/421/188/235/421188235.geojson
+++ b/data/421/188/235/421188235.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f81db48bd89122e05e741c89317260ab",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421188235,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346019,
     "wof:name":"Ponhea Lueu",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/188/239/421188239.geojson
+++ b/data/421/188/239/421188239.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7900223c3e5c761c3391a85f971bbb55",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421188239,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Kampong Leaeng",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/188/243/421188243.geojson
+++ b/data/421/188/243/421188243.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009539,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"746e7b1902d2b26c66e6258c36d7a0be",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421188243,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346018,
     "wof:name":"Prey Nob",
     "wof:parent_id":85673101,
     "wof:placetype":"county",

--- a/data/421/188/351/421188351.geojson
+++ b/data/421/188/351/421188351.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009542,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6597524bfc32c008b3c54e2c06309e2d",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421188351,
-    "wof:lastmodified":1566727524,
+    "wof:lastmodified":1582346019,
     "wof:name":"Khsach Kandal",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/191/397/421191397.geojson
+++ b/data/421/191/397/421191397.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bcc7e755229128579f6ee6a179352c2",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421191397,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Peam Ro",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/421/194/641/421194641.geojson
+++ b/data/421/194/641/421194641.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009814,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2145c59641ff643e86d609987a26583a",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421194641,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Veun Sai",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/194/643/421194643.geojson
+++ b/data/421/194/643/421194643.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009815,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8223f263c90021e7e3e3d140d2ec3d8",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421194643,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Kralanh",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/194/855/421194855.geojson
+++ b/data/421/194/855/421194855.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd8a96b1dab34d2161cf70c4c030484f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421194855,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Chbar Mon",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/421/194/857/421194857.geojson
+++ b/data/421/194/857/421194857.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94759c009454790d4f88acf673668499",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421194857,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Thma Bang",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/194/859/421194859.geojson
+++ b/data/421/194/859/421194859.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cbea26fbf0ea50a8713eff0b829dfe9",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421194859,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Kuleaen",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/421/195/831/421195831.geojson
+++ b/data/421/195/831/421195831.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009860,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f4e0a7907f0ad23f431bb9dfd21e986",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421195831,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346017,
     "wof:name":"Cheung Prey",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/421/196/403/421196403.geojson
+++ b/data/421/196/403/421196403.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009880,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4d37eb0e8205867d40b4c6a60185e97",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421196403,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Samlout",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/198/129/421198129.geojson
+++ b/data/421/198/129/421198129.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009938,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53a0f6de6bbece9ac959235280350afa",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421198129,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Ou Chrov",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/198/921/421198921.geojson
+++ b/data/421/198/921/421198921.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009966,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a87ea5b321edb88d56c98e398292339f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421198921,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Baray",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/198/923/421198923.geojson
+++ b/data/421/198/923/421198923.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459009966,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"121dceb8a59d139b768fa447cc072317",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421198923,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Rolea B'ier",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/200/831/421200831.geojson
+++ b/data/421/200/831/421200831.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"372c21b82b1209b69ae311e9c5406532",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421200831,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346019,
     "wof:name":"Svay Leu",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/200/833/421200833.geojson
+++ b/data/421/200/833/421200833.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a643be472a8d5d374ae02acd658275fa",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421200833,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346019,
     "wof:name":"Varin",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/200/835/421200835.geojson
+++ b/data/421/200/835/421200835.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2c9565d9a02b403ffe1125161abf958",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421200835,
-    "wof:lastmodified":1566727525,
+    "wof:lastmodified":1582346019,
     "wof:name":"Stueng Traeng",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/421/201/861/421201861.geojson
+++ b/data/421/201/861/421201861.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010090,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"660931fb54a795f949f7a67cf08dd8af",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421201861,
-    "wof:lastmodified":1566727526,
+    "wof:lastmodified":1582346019,
     "wof:name":"Mondol Seima",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/202/233/421202233.geojson
+++ b/data/421/202/233/421202233.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5728488c751cd6220acbe7871f5af7f",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421202233,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kampong Cham",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/421/202/235/421202235.geojson
+++ b/data/421/202/235/421202235.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0709d02ca947574f91080481098ff0c",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421202235,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Baribour",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/202/239/421202239.geojson
+++ b/data/421/202/239/421202239.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46c88eec699f0823ec0b7552b3e066ab",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421202239,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Sangkae",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/202/305/421202305.geojson
+++ b/data/421/202/305/421202305.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"963bccbbfc5443e13a9df5abe68daed5",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421202305,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kampong Trabaek",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/421/202/413/421202413.geojson
+++ b/data/421/202/413/421202413.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010117,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"760f1f075c1f3c8fba095339625315f7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421202413,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Botum Sakor",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/202/559/421202559.geojson
+++ b/data/421/202/559/421202559.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010122,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0ac78db3391fdc2f75ce6a6046f94c8",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421202559,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kampong Chhnang",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/203/239/421203239.geojson
+++ b/data/421/203/239/421203239.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfdc66c447bf28a8eedb43d9007fe396",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421203239,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Krakor",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/421/203/293/421203293.geojson
+++ b/data/421/203/293/421203293.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010146,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b70a17a53d3c82bb2bc1c28383258e83",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421203293,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Thma Puok",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/204/115/421204115.geojson
+++ b/data/421/204/115/421204115.geojson
@@ -235,6 +235,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97fa63e9e5bd693c931b05b21b3a1b55",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":421204115,
-    "wof:lastmodified":1566727522,
+    "wof:lastmodified":1582346018,
     "wof:name":"Siem Reap",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/205/043/421205043.geojson
+++ b/data/421/205/043/421205043.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"KH",
     "wof:created":1459010210,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7192916f4117e36032aae1860c595c5",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421205043,
-    "wof:lastmodified":1566727523,
+    "wof:lastmodified":1582346018,
     "wof:name":"Kampong Siem",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/856/323/59/85632359.geojson
+++ b/data/856/323/59/85632359.geojson
@@ -1052,6 +1052,11 @@
     },
     "wof:country":"KH",
     "wof:country_alpha3":"KHM",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"f558f16934723b328389e7253bf0b1d5",
     "wof:hierarchy":[
         {
@@ -1066,7 +1071,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727285,
+    "wof:lastmodified":1582346006,
     "wof:name":"Cambodia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/730/11/85673011.geojson
+++ b/data/856/730/11/85673011.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Banteay Meanchey Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64a20ead7e0134e00b47e306517ea5ad",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"B\u00e2nt\u00e9ay M\u00e9anchey",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/15/85673015.geojson
+++ b/data/856/730/15/85673015.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Battambang Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dba854575b4589b6e3e23394161cc653",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"Batd\u00e2mb\u00e2ng",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/19/85673019.geojson
+++ b/data/856/730/19/85673019.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Koh Kong Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd6ec70c0dccf6fa06384b85c70e94b3",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"Ka\u00f4h Kong",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/23/85673023.geojson
+++ b/data/856/730/23/85673023.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Pursat Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bcd12fd32114bd273f65fd00e556e97",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"Pouthisat",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/29/85673029.geojson
+++ b/data/856/730/29/85673029.geojson
@@ -283,6 +283,9 @@
         "wd:id":"Q652818"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"182998b352dea9210beeebd65c4e0e1d",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"Siemr\u00e9ab",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/33/85673033.geojson
+++ b/data/856/730/33/85673033.geojson
@@ -291,6 +291,9 @@
         "wd:id":"Q629538"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59c080a688344cc888b4573fc0a741e8",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"Otdar Mean Chey",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/37/85673037.geojson
+++ b/data/856/730/37/85673037.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Pailin Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9a273daad14e880a5dd7cb9b831ea5f",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"Krong Pailin",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/41/85673041.geojson
+++ b/data/856/730/41/85673041.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Kampong Cham Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0707ebb822779de6b963b52e89f32651",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"K\u00e2mp\u00f3ng Cham",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/47/85673047.geojson
+++ b/data/856/730/47/85673047.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Kampong Chhnang Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2dfd7662d2acad7ac053f69db6aee12c",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"K\u00e2mp\u00f3ng Chhnang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/51/85673051.geojson
+++ b/data/856/730/51/85673051.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Kandal Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d27fbab501790aceb263bde70e393cc7",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"K\u00e2ndal",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/53/85673053.geojson
+++ b/data/856/730/53/85673053.geojson
@@ -277,6 +277,9 @@
         "wd:id":"Q652867"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14236fd864a9c02e62a964c5a9750605",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"K\u00e2mp\u00f3ng Sp\u0153",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/57/85673057.geojson
+++ b/data/856/730/57/85673057.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Kampong Thom Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d290f1604bf2720babfc9ec70377fa0",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"K\u00e2mp\u00f3ng Thum",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/63/85673063.geojson
+++ b/data/856/730/63/85673063.geojson
@@ -517,6 +517,9 @@
         1125853197
     ],
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d90893307c4a5e82d36f1c07f66ab35",
     "wof:hierarchy":[
         {
@@ -532,7 +535,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"Phnom Penh",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/67/85673067.geojson
+++ b/data/856/730/67/85673067.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Prey Veng Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"911ae3f429bb6a42d67714be96b7a54e",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"Prey V\u00eang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/71/85673071.geojson
+++ b/data/856/730/71/85673071.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Preah Vihear Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3fd9b30fb7dfd890d32f2105a785a74",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"Preah Vih\u00e9ar ",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/75/85673075.geojson
+++ b/data/856/730/75/85673075.geojson
@@ -281,6 +281,9 @@
         "wd:id":"Q837889"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed03529f3762a0897f320f13476b14a6",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"St\u0153ng Tr\u00eang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/81/85673081.geojson
+++ b/data/856/730/81/85673081.geojson
@@ -280,6 +280,9 @@
         "wd:id":"Q785896"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a5e3118cf654cc393b7521306a2dfd2",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"Kr\u00e2ch\u00e9h",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/85/85673085.geojson
+++ b/data/856/730/85/85673085.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Mondulkiri Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74ab45a71d4c8b8e3419a611e0b6fd5d",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727284,
+    "wof:lastmodified":1582346005,
     "wof:name":"M\u00f4nd\u00f3l Kiri",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/89/85673089.geojson
+++ b/data/856/730/89/85673089.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q747846"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a7a08e51917d880572436c3e6e77966",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346004,
     "wof:name":"R\u00f4t\u00e2n\u00f4kiri",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/93/85673093.geojson
+++ b/data/856/730/93/85673093.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Kampot Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4414fc42456a18ee6d21d7a8db80a778",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346003,
     "wof:name":"K\u00e2mp\u00f4t",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/99/85673099.geojson
+++ b/data/856/730/99/85673099.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Kep Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f525d22033b3fc81b64637f14f89da69",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727283,
+    "wof:lastmodified":1582346005,
     "wof:name":"Kep",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/01/85673101.geojson
+++ b/data/856/731/01/85673101.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Sihanoukville (city)"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"213acf5c1db085ab3c3a2110d4a03a24",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727285,
+    "wof:lastmodified":1582346006,
     "wof:name":"Krong Preah Sihanouk",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/05/85673105.geojson
+++ b/data/856/731/05/85673105.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Svay Rieng Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d4249bad84b930dbba2f994fed230d4",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727285,
+    "wof:lastmodified":1582346006,
     "wof:name":"Svay Rieng",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/07/85673107.geojson
+++ b/data/856/731/07/85673107.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Tak\u00e9o Province"
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1969eb57f38c33f5e809007014a6a1ea",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1566727285,
+    "wof:lastmodified":1582346006,
     "wof:name":"Tak\u00eav",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/859/027/33/85902733.geojson
+++ b/data/859/027/33/85902733.geojson
@@ -78,6 +78,9 @@
         "qs:id":235411
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bdf70cc3e9708ff9e56f37419c647f2",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379374,
+    "wof:lastmodified":1582346002,
     "wof:name":"Toul Kork",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/35/85902735.geojson
+++ b/data/859/027/35/85902735.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":235409
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9c11de5d5f853ae1b3792bfc60f86cf",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566727282,
+    "wof:lastmodified":1582346002,
     "wof:name":"Toul Tapeung",
     "wof:parent_id":1108952563,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/37/85902737.geojson
+++ b/data/859/027/37/85902737.geojson
@@ -75,6 +75,9 @@
         "qs:id":1083521
     },
     "wof:country":"KH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82c7e376806a21e16408517c3415f5de",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379374,
+    "wof:lastmodified":1582346002,
     "wof:name":"Tuk Laak",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/440/787/890440787.geojson
+++ b/data/890/440/787/890440787.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"KH",
     "wof:created":1469052297,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"231368c41f883bc2931f9bd2772630e7",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":890440787,
-    "wof:lastmodified":1566727527,
+    "wof:lastmodified":1582346020,
     "wof:name":"Sameakki Mean Chey",
     "wof:parent_id":85673047,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.