### PR TITLE
Update properties of megacities

### DIFF
--- a/data/112/585/319/7/1125853197.geojson
+++ b/data/112/585/319/7/1125853197.geojson
@@ -233,10 +233,9 @@
         "\u041f\u043d\u043e\u043c\u043f\u0435\u043d\u044c"
     ],
     "name:khm_x_preferred":[
-        "Phnum P\u00e9nh"
+        "\u1797\u17d2\u1793\u17c6\u1796\u17c1\u1789"
     ],
     "name:khm_x_variant":[
-        "\u1797\u17d2\u1793\u17c6\u1796\u17c1\u1789",
         "\u1797\u17d2\u1793\u17c6\u1780\u17c6\u1796\u1784\u17cb\u178f\u17d2\u179a\u17b6\u1785"
     ],
     "name:kir_x_preferred":[
@@ -541,7 +540,7 @@
         }
     ],
     "wof:id":1125853197,
-    "wof:lastmodified":1608688179,
+    "wof:lastmodified":1610044966,
     "wof:megacity":1,
     "wof:name":"Phnom Penh",
     "wof:parent_id":1108564771,

--- a/data/112/585/319/7/1125853197.geojson
+++ b/data/112/585/319/7/1125853197.geojson
@@ -20,7 +20,7 @@
     "mz:hierarchy_label":1,
     "mz:is_approximate":1,
     "mz:is_current":1,
-    "mz:min_zoom":4.0,
+    "mz:min_zoom":5.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ace_x_preferred":[
         "Phnom Penh"
@@ -518,6 +518,7 @@
     ],
     "wof:concordances":{
         "gn:id":1821306,
+        "ne:id":1159151127,
         "qs_pg:id":89559,
         "wd:id":"Q1850"
     },
@@ -540,7 +541,8 @@
         }
     ],
     "wof:id":1125853197,
-    "wof:lastmodified":1607390892,
+    "wof:lastmodified":1608688179,
+    "wof:megacity":1,
     "wof:name":"Phnom Penh",
     "wof:parent_id":1108564771,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary