### PR TITLE
kh concordances, placetype local, and more

### DIFF
--- a/data/110/856/457/5/1108564575.geojson
+++ b/data/110/856/457/5/1108564575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070046,
-    "geom:area_square_m":840639453.236303,
+    "geom:area_square_m":840639453.236261,
     "geom:bbox":"107.152854891,13.784182665,107.473876,14.1346607611",
     "geom:latitude":13.934353,
     "geom:longitude":107.311845,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.RO.AM",
         "wd:id":"Q4754589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062589,
-    "wof:geomhash":"3975714ec27e00b35d742c57576d499f",
+    "wof:geomhash":"20c4f2ad677e3c8df07a98787f77a1e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564575,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Andoung Meas",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/457/7/1108564577.geojson
+++ b/data/110/856/457/7/1108564577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015038,
-    "geom:area_square_m":182182196.066295,
+    "geom:area_square_m":182182196.066264,
     "geom:bbox":"104.659539116,11.4449220159,104.768534597,11.6881389419",
     "geom:latitude":11.551936,
     "geom:longitude":104.71041,
@@ -80,9 +80,10 @@
         "hasc:id":"KH.KN.AS",
         "wd:id":"Q4763307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062591,
-    "wof:geomhash":"c955608899dc8fac3923f4ffeb98970c",
+    "wof:geomhash":"1f86d886a0e4af8d997b68d496d72d8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108564577,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Angk Snuol",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/457/9/1108564579.geojson
+++ b/data/110/856/457/9/1108564579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024859,
-    "geom:area_square_m":301750017.377441,
+    "geom:area_square_m":301750002.148809,
     "geom:bbox":"104.831935,10.841107,105.04835,11.102921",
     "geom:latitude":10.992661,
     "geom:longitude":104.95091,
@@ -98,9 +98,10 @@
         "hasc:id":"KH.TA.AB",
         "wd:id":"Q4763323"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062593,
-    "wof:geomhash":"7e9dc69cfb60f0ad88dca12017f6f9ce",
+    "wof:geomhash":"5c2ddd30317bf0ae08bd348d364b70e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108564579,
-    "wof:lastmodified":1690938122,
+    "wof:lastmodified":1695886194,
     "wof:name":"Angkor Borei",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/458/1/1108564581.geojson
+++ b/data/110/856/458/1/1108564581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026242,
-    "geom:area_square_m":318729731.275994,
+    "geom:area_square_m":318729731.276042,
     "geom:bbox":"104.530053593,10.6787545485,104.727200853,10.9074359969",
     "geom:latitude":10.805706,
     "geom:longitude":104.631882,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KP.AC",
         "wd:id":"Q4763325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062594,
-    "wof:geomhash":"5f878af4e5c84ce60d9610809806746c",
+    "wof:geomhash":"59d291c45fa3f48102e75df9fb504e30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564581,
-    "wof:lastmodified":1566727458,
+    "wof:lastmodified":1695886193,
     "wof:name":"Angkor Chey",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/458/3/1108564583.geojson
+++ b/data/110/856/458/3/1108564583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040002,
-    "geom:area_square_m":480529666.523135,
+    "geom:area_square_m":480529938.047311,
     "geom:bbox":"103.585655,13.591012,103.884054,13.847675",
     "geom:latitude":13.711751,
     "geom:longitude":103.711111,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.SI.AC",
         "wd:id":"Q1883711"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062595,
-    "wof:geomhash":"d9fe1493492b947ee7dcf2bd8a08d1a5",
+    "wof:geomhash":"554f101a28c25813edc8e21c43e4acb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564583,
-    "wof:lastmodified":1690938119,
+    "wof:lastmodified":1695886193,
     "wof:name":"Angkor Chum",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/458/5/1108564585.geojson
+++ b/data/110/856/458/5/1108564585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029795,
-    "geom:area_square_m":358125200.012088,
+    "geom:area_square_m":358125022.745478,
     "geom:bbox":"103.753451,13.458851,103.932856,13.70312",
     "geom:latitude":13.580545,
     "geom:longitude":103.854746,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SI.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062597,
-    "wof:geomhash":"22c6a1ebe444d2700b32d330304b02cd",
+    "wof:geomhash":"70e7aecee18a3bd307da26fb6847213c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564585,
-    "wof:lastmodified":1627522281,
+    "wof:lastmodified":1695886749,
     "wof:name":"Angkor Thum",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/458/9/1108564589.geojson
+++ b/data/110/856/458/9/1108564589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1285,
-    "geom:area_square_m":1540666305.384721,
+    "geom:area_square_m":1540666681.115665,
     "geom:bbox":"103.821393,13.955731,104.166591,14.378603",
     "geom:latitude":14.157946,
     "geom:longitude":103.998165,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.OC.AV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062598,
-    "wof:geomhash":"6eefd261f7f65967de1a090d69841877",
+    "wof:geomhash":"f8ff9e150c1f1d1bf1fb0aca71905335",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564589,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886749,
     "wof:name":"Anlong Veaeng",
     "wof:parent_id":85673033,
     "wof:placetype":"county",

--- a/data/110/856/459/1/1108564591.geojson
+++ b/data/110/856/459/1/1108564591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.197371,
-    "geom:area_square_m":2389481465.227071,
+    "geom:area_square_m":2389481385.990045,
     "geom:bbox":"103.772811,11.480087,104.304487,12.075546",
     "geom:latitude":11.739268,
     "geom:longitude":104.057916,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.KS.AR",
         "wd:id":"Q4778738"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062600,
-    "wof:geomhash":"7efd8d02d31b6cd77c7863d9d4089e3a",
+    "wof:geomhash":"5988764548a6cd6d931db3034e422af5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108564591,
-    "wof:lastmodified":1690938123,
+    "wof:lastmodified":1695886195,
     "wof:name":"Aoral",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/459/3/1108564593.geojson
+++ b/data/110/856/459/3/1108564593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02847,
-    "geom:area_square_m":345236159.701379,
+    "geom:area_square_m":345236134.673816,
     "geom:bbox":"105.315063,11.173456,105.539285,11.401695",
     "geom:latitude":11.282302,
     "geom:longitude":105.421796,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PY.BP",
         "wd:id":"Q4837067"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062601,
-    "wof:geomhash":"4c1ae13249028962c8b7b4aa3d75c18b",
+    "wof:geomhash":"1cd78f30f4edb74356efdd6e232c4c0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564593,
-    "wof:lastmodified":1690938123,
+    "wof:lastmodified":1695886195,
     "wof:name":"Ba Phnum",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/459/5/1108564595.geojson
+++ b/data/110/856/459/5/1108564595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15509,
-    "geom:area_square_m":1870601485.051004,
+    "geom:area_square_m":1870601485.051058,
     "geom:bbox":"103.460247908,12.3808492962,103.998895971,13.053045475",
     "geom:latitude":12.72647,
     "geom:longitude":103.763707,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PO.BK",
         "wd:id":"Q4849003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062603,
-    "wof:geomhash":"e293120a08d35ce08f47cb5cfc5ce262",
+    "wof:geomhash":"1b0699dcb127a223be7cb2c141cb2099",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564595,
-    "wof:lastmodified":1566727460,
+    "wof:lastmodified":1695886195,
     "wof:name":"Bakan",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/110/856/459/7/1108564597.geojson
+++ b/data/110/856/459/7/1108564597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072504,
-    "geom:area_square_m":873643087.554106,
+    "geom:area_square_m":873643130.665976,
     "geom:bbox":"102.830565,12.771547,103.222172,13.137404",
     "geom:latitude":12.971833,
     "geom:longitude":103.045933,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062605,
-    "wof:geomhash":"e4284a05ebcf1fc0498a54500e9a60b2",
+    "wof:geomhash":"1df8e76c5997fd4b3ae2b789ff244075",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108564597,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Banan",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/459/9/1108564599.geojson
+++ b/data/110/856/459/9/1108564599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113479,
-    "geom:area_square_m":1360493016.025471,
+    "geom:area_square_m":1360493016.025519,
     "geom:bbox":"103.034804206,13.9142280863,103.454364733,14.3793881679",
     "geom:latitude":14.170175,
     "geom:longitude":103.268368,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.OC.BA",
         "wd:id":"Q4857202"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062607,
-    "wof:geomhash":"b8f5e4dc1eff9a267e7d6201a944b038",
+    "wof:geomhash":"7877ddbfae40cd7d11f4db452ad2c88e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564599,
-    "wof:lastmodified":1566727460,
+    "wof:lastmodified":1695886195,
     "wof:name":"Banteay Ampil",
     "wof:parent_id":85673033,
     "wof:placetype":"county",

--- a/data/110/856/460/1/1108564601.geojson
+++ b/data/110/856/460/1/1108564601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033177,
-    "geom:area_square_m":403183145.145855,
+    "geom:area_square_m":403183145.146154,
     "geom:bbox":"104.509363625,10.527323,104.716815627,10.7761334233",
     "geom:latitude":10.639268,
     "geom:longitude":104.602567,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.KP.BM",
         "wd:id":"Q4857204"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062608,
-    "wof:geomhash":"6812593636a94d6c32f3055562971380",
+    "wof:geomhash":"b62bcb484f737d4a277b92e780b95532",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108564601,
-    "wof:lastmodified":1566727458,
+    "wof:lastmodified":1695886193,
     "wof:name":"Banteay Meas",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/460/3/1108564603.geojson
+++ b/data/110/856/460/3/1108564603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050342,
-    "geom:area_square_m":605096328.764353,
+    "geom:area_square_m":605096950.888907,
     "geom:bbox":"103.914037,13.421282,104.120769,13.76899",
     "geom:latitude":13.574999,
     "geom:longitude":104.014591,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.SI.BS",
         "wd:id":"Q4857206"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062609,
-    "wof:geomhash":"0709f6800176d13ba2b830ad76719c65",
+    "wof:geomhash":"113ce5ae4a53d2f7de778c83f165ac2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564603,
-    "wof:lastmodified":1690938121,
+    "wof:lastmodified":1695886193,
     "wof:name":"Banteay Srei",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/460/7/1108564607.geojson
+++ b/data/110/856/460/7/1108564607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039124,
-    "geom:area_square_m":469997494.885566,
+    "geom:area_square_m":469997494.885598,
     "geom:bbox":"107.07933534,13.5904754553,107.327393293,13.8389804607",
     "geom:latitude":13.708105,
     "geom:longitude":107.195403,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.RO.BK",
         "wd:id":"Q4857942"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062611,
-    "wof:geomhash":"dd6ae5d2eaa7d51999e0cd59143baae3",
+    "wof:geomhash":"cb806df4a5c70eecff5ad1497dee0a92",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564607,
-    "wof:lastmodified":1566727458,
+    "wof:lastmodified":1695886193,
     "wof:name":"Bar Kaev",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/460/9/1108564609.geojson
+++ b/data/110/856/460/9/1108564609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042259,
-    "geom:area_square_m":512621915.80078,
+    "geom:area_square_m":512621915.800823,
     "geom:bbox":"104.383614654,11.0770845815,104.692036726,11.3209236277",
     "geom:latitude":11.184152,
     "geom:longitude":104.536394,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.KS.BS",
         "wd:id":"Q4866644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062614,
-    "wof:geomhash":"10c4800ad46352e164b3788cfe918021",
+    "wof:geomhash":"a12ddd8394dcba44c772854895ef9543",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564609,
-    "wof:lastmodified":1566727458,
+    "wof:lastmodified":1695886193,
     "wof:name":"Basedth",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/461/1/1108564611.geojson
+++ b/data/110/856/461/1/1108564611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0552,
-    "geom:area_square_m":667571312.502796,
+    "geom:area_square_m":667571312.502553,
     "geom:bbox":"104.818481132,11.8063905429,105.027689791,12.264756483",
     "geom:latitude":12.030067,
     "geom:longitude":104.932053,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KC.BT",
         "wd:id":"Q4869002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062616,
-    "wof:geomhash":"cf27a0bd8afc90b025c392b67d3c6528",
+    "wof:geomhash":"a46f66723f3f6d7d6ae05b678e76cfcb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564611,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Batheay",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/461/3/1108564613.geojson
+++ b/data/110/856/461/3/1108564613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030939,
-    "geom:area_square_m":375179964.217062,
+    "geom:area_square_m":375180024.704278,
     "geom:bbox":"104.692775,11.200628,104.941685,11.353003",
     "geom:latitude":11.275369,
     "geom:longitude":104.819909,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"KH.TA.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062617,
-    "wof:geomhash":"a3854d3423367afb7a504012de250e55",
+    "wof:geomhash":"dfa2ddcba39c94eab3ef257ff1114713",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108564613,
-    "wof:lastmodified":1636500704,
+    "wof:lastmodified":1695886765,
     "wof:name":"Bati",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/461/5/1108564615.geojson
+++ b/data/110/856/461/5/1108564615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079904,
-    "geom:area_square_m":961771351.127837,
+    "geom:area_square_m":961771510.969442,
     "geom:bbox":"102.687731,13.036923,102.997773,13.411696",
     "geom:latitude":13.238178,
     "geom:longitude":102.827319,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.BV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062620,
-    "wof:geomhash":"39d33736c141eafe0e502b3e8cc51bdc",
+    "wof:geomhash":"93652151ca8f0e90a2a67e8187d6d083",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108564615,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Bavel",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/461/7/1108564617.geojson
+++ b/data/110/856/461/7/1108564617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016719,
-    "geom:area_square_m":202910703.661519,
+    "geom:area_square_m":202910637.966012,
     "geom:bbox":"105.953135,10.971624,106.206263,11.102091",
     "geom:latitude":11.042449,
     "geom:longitude":106.098764,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062622,
-    "wof:geomhash":"04f9cf450cad7faf3be4822a588cca80",
+    "wof:geomhash":"af2bdbc5e3880fb5e73882e78d48ac32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108564617,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Bavet",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/461/9/1108564619.geojson
+++ b/data/110/856/461/9/1108564619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02018,
-    "geom:area_square_m":245104530.770196,
+    "geom:area_square_m":245104530.770209,
     "geom:bbox":"104.852078924,10.6627346509,105.098419,10.915396375",
     "geom:latitude":10.813383,
     "geom:longitude":104.988777,
@@ -87,9 +87,10 @@
         "hasc:id":"KH.TA.BC",
         "wd:id":"Q4950138"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062623,
-    "wof:geomhash":"51464902c514e7d64b77dca9f9c40f66",
+    "wof:geomhash":"a78c906253d370294673a7a27a870c0d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108564619,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Borei Cholsar",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/462/1/1108564621.geojson
+++ b/data/110/856/462/1/1108564621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049999,
-    "geom:area_square_m":604131702.335904,
+    "geom:area_square_m":604131702.336065,
     "geom:bbox":"105.131788643,12.099335437,105.4218937,12.4015552153",
     "geom:latitude":12.268291,
     "geom:longitude":105.287797,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KC.CL",
         "wd:id":"Q4930163"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062625,
-    "wof:geomhash":"378e79429378a1199b482df08d4b9ac4",
+    "wof:geomhash":"0eb12cea40fa2216fd8772d1445c0d53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564621,
-    "wof:lastmodified":1566727455,
+    "wof:lastmodified":1695886190,
     "wof:name":"Chamkar Leu",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/462/5/1108564625.geojson
+++ b/data/110/856/462/5/1108564625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000776,
-    "geom:area_square_m":9402141.813084,
+    "geom:area_square_m":9402115.04452,
     "geom:bbox":"104.899798,11.526321,104.947304,11.555201",
     "geom:latitude":11.543512,
     "geom:longitude":104.923087,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062627,
-    "wof:geomhash":"fbcd9dbc6ef979535744135cf3d52aa6",
+    "wof:geomhash":"d7550c8da5560ce5daa340938a699954",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564625,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chamkar Mon",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/462/7/1108564627.geojson
+++ b/data/110/856/462/7/1108564627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022811,
-    "geom:area_square_m":276970229.657381,
+    "geom:area_square_m":276970300.588851,
     "geom:bbox":"106.033686,10.790262,106.18951,11.047756",
     "geom:latitude":10.906036,
     "geom:longitude":106.103439,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062628,
-    "wof:geomhash":"3f33b5bad53e42317d9fdaea6814ea54",
+    "wof:geomhash":"66e07a4e990d3b46c5966356b4152072",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564627,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chantrea",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/462/9/1108564629.geojson
+++ b/data/110/856/462/9/1108564629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007227,
-    "geom:area_square_m":87569617.486835,
+    "geom:area_square_m":87569579.370982,
     "geom:bbox":"104.931552,11.460736,105.049637,11.556667",
     "geom:latitude":11.506764,
     "geom:longitude":104.987508,
@@ -85,9 +85,10 @@
         "hasc:id":"KH.KN.KS",
         "wd:id":"Q4886889"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062630,
-    "wof:geomhash":"be07422960d603842f4ce85bb6b4a642",
+    "wof:geomhash":"d6a0b8bb5dd924f9ef039327fadc25ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108564629,
-    "wof:lastmodified":1690938114,
+    "wof:lastmodified":1695886190,
     "wof:name":"Chbar Ampov",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/463/1/1108564631.geojson
+++ b/data/110/856/463/1/1108564631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121632,
-    "geom:area_square_m":1467932652.472912,
+    "geom:area_square_m":1467932394.239348,
     "geom:bbox":"105.989867,12.336251,106.409109,12.790705",
     "geom:latitude":12.57369,
     "geom:longitude":106.204124,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KH.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062632,
-    "wof:geomhash":"6d81cce6e04a446867d1b5f296c5081c",
+    "wof:geomhash":"6c1eb51455cc0192ff0f030e10278964",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108564631,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chetr Borei",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/110/856/463/3/1108564633.geojson
+++ b/data/110/856/463/3/1108564633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092622,
-    "geom:area_square_m":1113256552.97812,
+    "geom:area_square_m":1113256318.197455,
     "geom:bbox":"105.103897,13.445203,105.577295,13.753307",
     "geom:latitude":13.582978,
     "geom:longitude":105.342856,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PH.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062634,
-    "wof:geomhash":"54f72e01db1fc01da37eb9941e0979ed",
+    "wof:geomhash":"07e43a50e26a8d766cfd698f936b2753",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564633,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chey Saen",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/463/5/1108564635.geojson
+++ b/data/110/856/463/5/1108564635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072,
-    "geom:area_square_m":870259494.219829,
+    "geom:area_square_m":870259465.857763,
     "geom:bbox":"105.831417,11.953133,106.302168,12.366355",
     "geom:latitude":12.179455,
     "geom:longitude":106.112942,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KH.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062637,
-    "wof:geomhash":"553aa880143fd868560cbb2e160273fc",
+    "wof:geomhash":"71140381b0f8c67a783a4d4a9ec4ed0e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564635,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chhloung",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/110/856/463/7/1108564637.geojson
+++ b/data/110/856/463/7/1108564637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107209,
-    "geom:area_square_m":1301560148.543581,
+    "geom:area_square_m":1301559911.991606,
     "geom:bbox":"104.05817,10.760732,104.564976,11.172214",
     "geom:latitude":10.942755,
     "geom:longitude":104.26423,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KP.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062638,
-    "wof:geomhash":"8d95ce3e819451d41838cb971852cc14",
+    "wof:geomhash":"3e1011f0b7ee740824a049e02f423a73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564637,
-    "wof:lastmodified":1627522282,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chhuk",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/463/9/1108564639.geojson
+++ b/data/110/856/463/9/1108564639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200329,
-    "geom:area_square_m":2411621559.814713,
+    "geom:area_square_m":2411622245.342721,
     "geom:bbox":"104.130851,12.748222,104.680289,13.552829",
     "geom:latitude":13.201881,
     "geom:longitude":104.36512,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SI.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062640,
-    "wof:geomhash":"a9569daf7474d15282c1dd37a2fe5311",
+    "wof:geomhash":"77ca39f7e5ca9d4bc045e2e32b225a0d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564639,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chi Kraeng",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/464/3/1108564643.geojson
+++ b/data/110/856/464/3/1108564643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314788,
-    "geom:area_square_m":3774106121.745496,
+    "geom:area_square_m":3774106695.451721,
     "geom:bbox":"104.445212,13.932569,105.390692,14.437626",
     "geom:latitude":14.162206,
     "geom:longitude":104.859005,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.PH.CK",
         "wd:id":"Q4929072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062641,
-    "wof:geomhash":"9fc9a256c275efe28ffd772d0405defb",
+    "wof:geomhash":"e9a86a856c019bd331082fe7d808a0b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564643,
-    "wof:lastmodified":1690938113,
+    "wof:lastmodified":1695886189,
     "wof:name":"Choam Ksant",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/464/5/1108564645.geojson
+++ b/data/110/856/464/5/1108564645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027435,
-    "geom:area_square_m":331622563.161443,
+    "geom:area_square_m":331622563.161436,
     "geom:bbox":"104.706463878,12.0080365602,104.903515977,12.296233622",
     "geom:latitude":12.159247,
     "geom:longitude":104.822682,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.KG.CK",
         "wd:id":"Q4930069"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062643,
-    "wof:geomhash":"029ee8116f0939fa2147b50f40c2c8db",
+    "wof:geomhash":"e8e92ad7cb1b2e8362a51e7bc3f94998",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564645,
-    "wof:lastmodified":1566727454,
+    "wof:lastmodified":1695886189,
     "wof:name":"Chol Kiri",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/110/856/464/7/1108564647.geojson
+++ b/data/110/856/464/7/1108564647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070611,
-    "geom:area_square_m":847095580.205714,
+    "geom:area_square_m":847095156.216624,
     "geom:bbox":"103.385574,13.880749,103.831841,14.127438",
     "geom:latitude":14.022557,
     "geom:longitude":103.609212,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.OC.CK",
         "wd:id":"Q4930099"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062644,
-    "wof:geomhash":"5ce27145ea82b0a160543aca36759a04",
+    "wof:geomhash":"20fd9934123f9cd2280b920e0b8915d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564647,
-    "wof:lastmodified":1690938113,
+    "wof:lastmodified":1695886189,
     "wof:name":"Chong Kal",
     "wof:parent_id":85673033,
     "wof:placetype":"county",

--- a/data/110/856/464/9/1108564649.geojson
+++ b/data/110/856/464/9/1108564649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007214,
-    "geom:area_square_m":87357251.167956,
+    "geom:area_square_m":87357315.177174,
     "geom:bbox":"104.863343,11.565415,104.968137,11.736734",
     "geom:latitude":11.666198,
     "geom:longitude":104.924915,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062646,
-    "wof:geomhash":"4f4e67a12a4630c2d656f1f25a4b3ca7",
+    "wof:geomhash":"b9b1926c0b2225ac51a2a044a62ac019",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108564649,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Chraoy Chongvar",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/465/1/1108564651.geojson
+++ b/data/110/856/465/1/1108564651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037162,
-    "geom:area_square_m":451097935.928823,
+    "geom:area_square_m":451097935.928772,
     "geom:bbox":"104.354981377,10.8490156891,104.542499927,11.1471556499",
     "geom:latitude":10.982942,
     "geom:longitude":104.4341,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KP.CK",
         "wd:id":"Q4929362"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062647,
-    "wof:geomhash":"bf06f108e4a817009eedf943afd9e23c",
+    "wof:geomhash":"7c4b8e43b7969b306514abf5a642cb79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564651,
-    "wof:lastmodified":1566727454,
+    "wof:lastmodified":1695886189,
     "wof:name":"Chum Kiri",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/465/3/1108564653.geojson
+++ b/data/110/856/465/3/1108564653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060501,
-    "geom:area_square_m":731649736.078147,
+    "geom:area_square_m":731649367.150146,
     "geom:bbox":"105.785441,11.842352,106.018246,12.219879",
     "geom:latitude":12.037794,
     "geom:longitude":105.90057,
@@ -90,9 +90,10 @@
         "hasc:id":"KH.TB.DB",
         "wd:id":"Q5212074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062649,
-    "wof:geomhash":"c3cd8e13879553982f2f194b7569e366",
+    "wof:geomhash":"b33c14d394a98313c9e068e3b2b2d540",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108564653,
-    "wof:lastmodified":1690938114,
+    "wof:lastmodified":1695886190,
     "wof:name":"Dambae",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/110/856/465/5/1108564655.geojson
+++ b/data/110/856/465/5/1108564655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005951,
-    "geom:area_square_m":72345107.14714,
+    "geom:area_square_m":72345230.013041,
     "geom:bbox":"104.343721,10.445389,104.425959,10.578528",
     "geom:latitude":10.511899,
     "geom:longitude":104.381004,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KB.DC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062655,
-    "wof:geomhash":"b506a6a0d571bf812e54102bffb00aac",
+    "wof:geomhash":"82f8e0f1686fa42fecd91d3d7de704bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564655,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Damnak Chang'aeur",
     "wof:parent_id":85673099,
     "wof:placetype":"county",

--- a/data/110/856/465/7/1108564657.geojson
+++ b/data/110/856/465/7/1108564657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026143,
-    "geom:area_square_m":317632008.503987,
+    "geom:area_square_m":317632008.503959,
     "geom:bbox":"104.301242272,10.6213554328,104.531621798,10.7910082193",
     "geom:latitude":10.707294,
     "geom:longitude":104.422139,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KP.DT",
         "wd:id":"Q5215951"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062657,
-    "wof:geomhash":"65d05c0c233ab5a82c9d7c2c9a7bc52b",
+    "wof:geomhash":"32902da1fc4957729e30eaa96a6f9df5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564657,
-    "wof:lastmodified":1566727454,
+    "wof:lastmodified":1695886189,
     "wof:name":"Dang Tong",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/466/1/1108564661.geojson
+++ b/data/110/856/466/1/1108564661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009535,
-    "geom:area_square_m":115549128.250362,
+    "geom:area_square_m":115549240.203817,
     "geom:bbox":"104.777778,11.423665,104.923543,11.521956",
     "geom:latitude":11.469171,
     "geom:longitude":104.860358,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062658,
-    "wof:geomhash":"4db545bdedaf4f41beee0dad531b85eb",
+    "wof:geomhash":"37cdb27b082e60b2897782918707f82a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564661,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Dangkao",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/466/3/1108564663.geojson
+++ b/data/110/856/466/3/1108564663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000798,
-    "geom:area_square_m":9667617.573504,
+    "geom:area_square_m":9667648.419106,
     "geom:bbox":"104.902584,11.552569,104.952001,11.591964",
     "geom:latitude":11.570366,
     "geom:longitude":104.925309,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.DP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062660,
-    "wof:geomhash":"89589e0a59523d3d9d420ab6424bae7f",
+    "wof:geomhash":"8d7005991979ecd5559340ee4bca94c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564663,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Doun Penh",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/466/5/1108564665.geojson
+++ b/data/110/856/466/5/1108564665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006288,
-    "geom:area_square_m":76445451.579122,
+    "geom:area_square_m":76445683.543702,
     "geom:bbox":"104.263856,10.474556,104.356585,10.587746",
     "geom:latitude":10.533169,
     "geom:longitude":104.31251,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KB.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062662,
-    "wof:geomhash":"9b23d0405e9fda355c12bf1198e20699",
+    "wof:geomhash":"5c1bfef251f161530bd126e72f853d0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564665,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Kaeb",
     "wof:parent_id":85673099,
     "wof:placetype":"county",

--- a/data/110/856/466/7/1108564667.geojson
+++ b/data/110/856/466/7/1108564667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232803,
-    "geom:area_square_m":2811066738.450849,
+    "geom:area_square_m":2811066738.451196,
     "geom:bbox":"106.357768455,12.06183,107.046125205,12.760457542",
     "geom:latitude":12.4389,
     "geom:longitude":106.735038,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.MK.KS",
         "wd:id":"Q6346045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062663,
-    "wof:geomhash":"597a2d07ef250b89d6ae7a406315da4e",
+    "wof:geomhash":"384d6c72e9e1266aef6d3038fabfca6d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564667,
-    "wof:lastmodified":1566727460,
+    "wof:lastmodified":1695886196,
     "wof:name":"Kaev Seima",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/110/856/466/9/1108564669.geojson
+++ b/data/110/856/466/9/1108564669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038255,
-    "geom:area_square_m":463387631.545576,
+    "geom:area_square_m":463387631.545605,
     "geom:bbox":"105.461089073,11.4266356457,105.802378664,11.7191974364",
     "geom:latitude":11.588844,
     "geom:longitude":105.641899,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PY.KM",
         "wd:id":"Q4929411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062665,
-    "wof:geomhash":"0c43f0b908b861985a50942b5614e7c9",
+    "wof:geomhash":"9e058ee1a214fe3fa8903e361330a4c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564669,
-    "wof:lastmodified":1566727460,
+    "wof:lastmodified":1695886196,
     "wof:name":"Kamchay Mear",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/467/1/1108564671.geojson
+++ b/data/110/856/467/1/1108564671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032758,
-    "geom:area_square_m":397701420.245803,
+    "geom:area_square_m":397701410.735737,
     "geom:bbox":"105.796094,10.833239,106.066577,11.046423",
     "geom:latitude":10.940088,
     "geom:longitude":105.942692,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.SR.KR",
         "wd:id":"Q8011114"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062669,
-    "wof:geomhash":"913627a8612a39be71ec1707a391377f",
+    "wof:geomhash":"a4af42d82b1c0e36bec3d12eae2bb336",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564671,
-    "wof:lastmodified":1690938120,
+    "wof:lastmodified":1695886193,
     "wof:name":"Kampong Rou",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/467/3/1108564673.geojson
+++ b/data/110/856/467/3/1108564673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082082,
-    "geom:area_square_m":995825332.122734,
+    "geom:area_square_m":995825553.679454,
     "geom:bbox":"103.785455,10.902463,104.077972,11.433721",
     "geom:latitude":11.142043,
     "geom:longitude":103.946426,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KK.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062671,
-    "wof:geomhash":"c89fbb92501b46cdd74c4812a54a3432",
+    "wof:geomhash":"27a04391a6cfcd7a9416dbbe6dd83c5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564673,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Kampong Seila",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/110/856/467/5/1108564675.geojson
+++ b/data/110/856/467/5/1108564675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030798,
-    "geom:area_square_m":374408410.784516,
+    "geom:area_square_m":374408335.119765,
     "geom:bbox":"104.362727,10.404543,104.600472,10.632484",
     "geom:latitude":10.531674,
     "geom:longitude":104.476656,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.KP.KT",
         "wd:id":"Q1385801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062675,
-    "wof:geomhash":"b1457e598f61674e5d683e1cfd168a6d",
+    "wof:geomhash":"f02718bb5c18bae260304ca190991e6a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108564675,
-    "wof:lastmodified":1690938120,
+    "wof:lastmodified":1695886193,
     "wof:name":"Kampong Trach",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/467/9/1108564679.geojson
+++ b/data/110/856/467/9/1108564679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038642,
-    "geom:area_square_m":467412673.463048,
+    "geom:area_square_m":467412841.949999,
     "geom:bbox":"104.626362,11.82725,104.894421,12.120663",
     "geom:latitude":11.976901,
     "geom:longitude":104.753894,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KG.KT",
         "wd:id":"Q1385857"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062676,
-    "wof:geomhash":"456a532a51c8d6ed8e2f319387f24e2f",
+    "wof:geomhash":"dd9adee6cf77f4293f5f49a350efb432",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564679,
-    "wof:lastmodified":1690938119,
+    "wof:lastmodified":1695886193,
     "wof:name":"Kampong Tralach",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/110/856/468/1/1108564681.geojson
+++ b/data/110/856/468/1/1108564681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00464,
-    "geom:area_square_m":56392675.80369,
+    "geom:area_square_m":56392946.853242,
     "geom:bbox":"104.11995,10.537917,104.222084,10.64159",
     "geom:latitude":10.595587,
     "geom:longitude":104.170228,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KP.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062678,
-    "wof:geomhash":"08f17179653ef357a5f425fdbbda3e97",
+    "wof:geomhash":"692051368622598e5be09b8107422d36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108564681,
-    "wof:lastmodified":1636500704,
+    "wof:lastmodified":1695886765,
     "wof:name":"Kampot",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/468/3/1108564683.geojson
+++ b/data/110/856/468/3/1108564683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044144,
-    "geom:area_square_m":531593769.903075,
+    "geom:area_square_m":531593834.945557,
     "geom:bbox":"102.39166,12.978367,102.761832,13.201069",
     "geom:latitude":13.121466,
     "geom:longitude":102.561896,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062679,
-    "wof:geomhash":"5473cb34234ff9d2bfe394e17d9409af",
+    "wof:geomhash":"5536db3269a816864af27bafdedf6e87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564683,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Kamrieng",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/468/5/1108564685.geojson
+++ b/data/110/856/468/5/1108564685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019388,
-    "geom:area_square_m":235008348.404192,
+    "geom:area_square_m":235008348.404193,
     "geom:bbox":"104.655883703,11.3290068425,104.960602932,11.4619183974",
     "geom:latitude":11.395546,
     "geom:longitude":104.833472,
@@ -80,9 +80,10 @@
         "hasc:id":"KH.KN.KD",
         "wd:id":"Q6361246"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062681,
-    "wof:geomhash":"bd36a4e18a73d0e497c66df4160baa7d",
+    "wof:geomhash":"7a366e2102609a5d784d712491bf3308",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108564685,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Kandal Stueng",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/468/7/1108564687.geojson
+++ b/data/110/856/468/7/1108564687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072351,
-    "geom:area_square_m":872629091.483795,
+    "geom:area_square_m":872629091.483994,
     "geom:bbox":"103.88187535,12.5488692199,104.175359038,12.9466752005",
     "geom:latitude":12.733198,
     "geom:longitude":104.015801,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PO.KD",
         "wd:id":"Q6361505"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062682,
-    "wof:geomhash":"b121de69a773ae21625fdb7673d0a6e2",
+    "wof:geomhash":"6ff355484f7e316027f6b0f66a1ef1be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564687,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886194,
     "wof:name":"Kandieng",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/110/856/468/9/1108564689.geojson
+++ b/data/110/856/468/9/1108564689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032503,
-    "geom:area_square_m":393217867.076914,
+    "geom:area_square_m":393217792.160614,
     "geom:bbox":"104.987966,11.843915,105.344859,12.021963",
     "geom:latitude":11.938857,
     "geom:longitude":105.148468,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KC.KM",
         "wd:id":"Q6362249"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062684,
-    "wof:geomhash":"188f879bde9e36a52e7daf2d3198dc12",
+    "wof:geomhash":"63203495b0bbad137f1a835b70ef1773",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564689,
-    "wof:lastmodified":1690938122,
+    "wof:lastmodified":1695886195,
     "wof:name":"Kang Meas",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/469/1/1108564691.geojson
+++ b/data/110/856/469/1/1108564691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026247,
-    "geom:area_square_m":317821211.782189,
+    "geom:area_square_m":317820952.879878,
     "geom:bbox":"105.37943,11.597993,105.722198,11.756868",
     "geom:latitude":11.685746,
     "geom:longitude":105.559552,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PY.KC",
         "wd:id":"Q4929327"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062685,
-    "wof:geomhash":"e7c009fba6fb89a2dfd448075be5675f",
+    "wof:geomhash":"4c89846ce79a32945c9027fe59f38dc1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564691,
-    "wof:lastmodified":1690938121,
+    "wof:lastmodified":1695886195,
     "wof:name":"Kanhchriech",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/469/3/1108564693.geojson
+++ b/data/110/856/469/3/1108564693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028946,
-    "geom:area_square_m":351639546.662165,
+    "geom:area_square_m":351639546.662152,
     "geom:bbox":"104.808700666,10.6352749176,105.016172373,10.8461858271",
     "geom:latitude":10.749483,
     "geom:longitude":104.926121,
@@ -80,9 +80,10 @@
         "hasc:id":"KH.TA.KA",
         "wd:id":"Q4929064"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062687,
-    "wof:geomhash":"9e3cfe09979e97af4781b6debffd607c",
+    "wof:geomhash":"29e65d37b131db6d36b5d5611b850d14",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108564693,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886195,
     "wof:name":"Kaoh Andaet",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/469/7/1108564697.geojson
+++ b/data/110/856/469/7/1108564697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1861,
-    "geom:area_square_m":2256283400.008799,
+    "geom:area_square_m":2256283400.009598,
     "geom:bbox":"102.974555969,10.855360985,103.477568591,11.6441934112",
     "geom:latitude":11.332582,
     "geom:longitude":103.226485,
@@ -79,9 +79,10 @@
         "hasc:id":"KH.KK.KK",
         "wd:id":"Q1385849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062688,
-    "wof:geomhash":"d6487197b81fad3e6bd03864141f5de6",
+    "wof:geomhash":"5de88e6e385cf35d8dd83ca40c450603",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108564697,
-    "wof:lastmodified":1566727459,
+    "wof:lastmodified":1695886195,
     "wof:name":"Kaoh Kong",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/110/856/469/9/1108564699.geojson
+++ b/data/110/856/469/9/1108564699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.439563,
-    "geom:area_square_m":5293753362.03586,
+    "geom:area_square_m":5293754366.938272,
     "geom:bbox":"106.338916,12.836241,107.602729,13.418234",
     "geom:latitude":13.103276,
     "geom:longitude":106.966764,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.MK.KN",
         "wd:id":"Q4929526"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062690,
-    "wof:geomhash":"cd551d7371976d50a89f028e0fb0ec67",
+    "wof:geomhash":"8fdc87dd3d544c38976ce8ae2e676e59",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564699,
-    "wof:lastmodified":1690938121,
+    "wof:lastmodified":1695886193,
     "wof:name":"Kaoh Nheaek",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/110/856/470/1/1108564701.geojson
+++ b/data/110/856/470/1/1108564701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015484,
-    "geom:area_square_m":187359656.02618,
+    "geom:area_square_m":187359689.184519,
     "geom:bbox":"105.263402,11.825255,105.469352,11.943271",
     "geom:latitude":11.887985,
     "geom:longitude":105.369361,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KC.KT",
         "wd:id":"Q4930676"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062691,
-    "wof:geomhash":"4a6d3c0434b1b26daa708cbe4fbad256",
+    "wof:geomhash":"b64b1f70b0951a0b7bbe7bd03afd0c07",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564701,
-    "wof:lastmodified":1690938112,
+    "wof:lastmodified":1695886188,
     "wof:name":"Kaoh Soutin",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/470/3/1108564703.geojson
+++ b/data/110/856/470/3/1108564703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039743,
-    "geom:area_square_m":482249653.327856,
+    "geom:area_square_m":482249656.282565,
     "geom:bbox":"104.990997,10.897906,105.16354,11.242857",
     "geom:latitude":11.088449,
     "geom:longitude":105.084028,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KN.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062693,
-    "wof:geomhash":"5b50a7b3a6843e8466adb1c0bbccab86",
+    "wof:geomhash":"ad7718189983028b27eea7d5da7f268d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564703,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Kaoh Thum",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/470/5/1108564705.geojson
+++ b/data/110/856/470/5/1108564705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007738,
-    "geom:area_square_m":93732754.760161,
+    "geom:area_square_m":93732773.538585,
     "geom:bbox":"102.972916,11.53875,103.095172,11.649708",
     "geom:latitude":11.596774,
     "geom:longitude":103.03075,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KK.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062694,
-    "wof:geomhash":"385fe961d21c7a29bd8ea26ad5a3e7a3",
+    "wof:geomhash":"7d669ecfb9d3fb16ab1fc5cf5c58a918",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108564705,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886751,
     "wof:name":"Khemara Phoumin",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/110/856/470/7/1108564707.geojson
+++ b/data/110/856/470/7/1108564707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026133,
-    "geom:area_square_m":316739631.210881,
+    "geom:area_square_m":316739716.298647,
     "geom:bbox":"105.026668,11.311402,105.274818,11.53917",
     "geom:latitude":11.41903,
     "geom:longitude":105.144164,
@@ -95,9 +95,10 @@
         "hasc:id":"KH.KN.KS",
         "wd:id":"Q4886889"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062696,
-    "wof:geomhash":"5794d3ad66c249440f6cb4599bac1428",
+    "wof:geomhash":"3fc924593de00499a23c544b018784f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108564707,
-    "wof:lastmodified":1690938112,
+    "wof:lastmodified":1695886188,
     "wof:name":"Kien Svay",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/470/9/1108564709.geojson
+++ b/data/110/856/470/9/1108564709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048615,
-    "geom:area_square_m":590801019.241931,
+    "geom:area_square_m":590801173.29897,
     "geom:bbox":"104.672784,10.517929,104.95474,10.782045",
     "geom:latitude":10.639264,
     "geom:longitude":104.796832,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.TA.KV",
         "wd:id":"Q4930130"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062698,
-    "wof:geomhash":"50f0e6f7dd7cb7d7dbb3a1f7b2ed40fd",
+    "wof:geomhash":"1d899178818bf01f1f71244d559ec48d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564709,
-    "wof:lastmodified":1690938111,
+    "wof:lastmodified":1695886188,
     "wof:name":"Kiri Vong",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/471/1/1108564711.geojson
+++ b/data/110/856/471/1/1108564711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090854,
-    "geom:area_square_m":1096026643.394961,
+    "geom:area_square_m":1096026815.467155,
     "geom:bbox":"102.996546,12.436952,103.356656,12.910591",
     "geom:latitude":12.679888,
     "geom:longitude":103.18262,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062699,
-    "wof:geomhash":"d7fef300ff4ab7d962008bb276fb8ebe",
+    "wof:geomhash":"dce96374edd7ea9ffafdd877e68a7d22",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108564711,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886751,
     "wof:name":"Koas Krala",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/471/5/1108564715.geojson
+++ b/data/110/856/471/5/1108564715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031581,
-    "geom:area_square_m":382912719.240794,
+    "geom:area_square_m":382912719.24058,
     "geom:bbox":"104.536380626,11.1891665695,104.789342268,11.4353523593",
     "geom:latitude":11.317427,
     "geom:longitude":104.657232,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KS.KP",
         "wd:id":"Q4929012"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062701,
-    "wof:geomhash":"e0d91250d5523537afd73111a118b4d5",
+    "wof:geomhash":"f0a0d79267efcae276c31d14bf8f9c91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564715,
-    "wof:lastmodified":1566727451,
+    "wof:lastmodified":1695886186,
     "wof:name":"Kong Pisei",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/471/7/1108564717.geojson
+++ b/data/110/856/471/7/1108564717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175198,
-    "geom:area_square_m":2106340352.819312,
+    "geom:area_square_m":2106340194.798562,
     "geom:bbox":"106.52909,13.172333,106.960583,13.822705",
     "geom:latitude":13.517773,
     "geom:longitude":106.751193,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.RO.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062702,
-    "wof:geomhash":"dc6c366eb03a604d74dc9fc6164728f7",
+    "wof:geomhash":"283fe6f44ea87a1b397d793d8322f903",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564717,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886751,
     "wof:name":"Koun Mom",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/471/9/1108564719.geojson
+++ b/data/110/856/471/9/1108564719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046527,
-    "geom:area_square_m":562326578.434838,
+    "geom:area_square_m":562326347.319415,
     "geom:bbox":"105.530882,12.087317,105.842757,12.300543",
     "geom:latitude":12.195984,
     "geom:longitude":105.676666,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.TB.KC",
         "wd:id":"Q4930636"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062706,
-    "wof:geomhash":"0a750ce6ea876a76c22cbf81f4482448",
+    "wof:geomhash":"ad12635384f70e5014a2f5e14f255af5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564719,
-    "wof:lastmodified":1690938109,
+    "wof:lastmodified":1695886186,
     "wof:name":"Krouch Chhmar",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/110/856/472/1/1108564721.geojson
+++ b/data/110/856/472/1/1108564721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03124,
-    "geom:area_square_m":378984430.162051,
+    "geom:area_square_m":378984528.572882,
     "geom:bbox":"105.128562,10.911485,105.282647,11.328778",
     "geom:latitude":11.161795,
     "geom:longitude":105.198515,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.KN.LD",
         "wd:id":"Q4930358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062709,
-    "wof:geomhash":"b4e2755ac44c630e484eb6fe77c221e2",
+    "wof:geomhash":"c205fb31c4e709217855442e8109f12d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564721,
-    "wof:lastmodified":1690938116,
+    "wof:lastmodified":1695886190,
     "wof:name":"Leuk Daek",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/472/3/1108564723.geojson
+++ b/data/110/856/472/3/1108564723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152592,
-    "geom:area_square_m":1835268449.82444,
+    "geom:area_square_m":1835268912.09337,
     "geom:bbox":"106.845277,13.171389,107.377389,13.697121",
     "geom:latitude":13.425065,
     "geom:longitude":107.081545,
@@ -143,9 +143,10 @@
         "hasc:id":"KH.RO.LP",
         "wd:id":"Q2235920"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062710,
-    "wof:geomhash":"a228e7c467ebf0d6189202d596d171cf",
+    "wof:geomhash":"e47f155bd91b3a267728d8d12be6b21f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108564723,
-    "wof:lastmodified":1690938117,
+    "wof:lastmodified":1695886765,
     "wof:name":"Lumphat",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/472/5/1108564725.geojson
+++ b/data/110/856/472/5/1108564725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022057,
-    "geom:area_square_m":267238076.535673,
+    "geom:area_square_m":267238168.023373,
     "geom:bbox":"104.945002,11.392163,105.302079,11.642834",
     "geom:latitude":11.524527,
     "geom:longitude":105.122137,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KN.LA",
         "wd:id":"Q4930020"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062712,
-    "wof:geomhash":"c8db47b13ad3f9ae9809706359c0fdaa",
+    "wof:geomhash":"315c8ed5573332d423660df7716dbb20",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564725,
-    "wof:lastmodified":1690938117,
+    "wof:lastmodified":1695886191,
     "wof:name":"Lvea Aem",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/472/7/1108564727.geojson
+++ b/data/110/856/472/7/1108564727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042423,
-    "geom:area_square_m":510032244.955672,
+    "geom:area_square_m":510032244.955741,
     "geom:bbox":"102.333542,13.4436900292,102.829386965,13.6091227696",
     "geom:latitude":13.521341,
     "geom:longitude":102.56926,
@@ -98,9 +98,10 @@
         "hasc:id":"KH.OM.ML",
         "wd:id":"Q4929080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062713,
-    "wof:geomhash":"09c46e6696874b3193c987b110e69c63",
+    "wof:geomhash":"b225eea3e20d2e168bba8deba31496e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108564727,
-    "wof:lastmodified":1566727456,
+    "wof:lastmodified":1695886191,
     "wof:name":"Malai",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/110/856/472/9/1108564729.geojson
+++ b/data/110/856/472/9/1108564729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033788,
-    "geom:area_square_m":409622305.440254,
+    "geom:area_square_m":409622305.440387,
     "geom:bbox":"105.456659268,11.2068828939,105.669162844,11.4868262064",
     "geom:latitude":11.355077,
     "geom:longitude":105.573866,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.PY.MS",
         "wd:id":"Q4929602"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062714,
-    "wof:geomhash":"a8963f806eab6bdf8b424d7537cd9244",
+    "wof:geomhash":"3c73069ece5096eda0c98e356d0a8402",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564729,
-    "wof:lastmodified":1566727456,
+    "wof:lastmodified":1695886191,
     "wof:name":"Me Sang",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/473/3/1108564733.geojson
+++ b/data/110/856/473/3/1108564733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002401,
-    "geom:area_square_m":29090544.025271,
+    "geom:area_square_m":29090546.1295,
     "geom:bbox":"104.861559,11.481486,104.945433,11.550295",
     "geom:latitude":11.520689,
     "geom:longitude":104.905821,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062716,
-    "wof:geomhash":"699f864644aeb93ae7c07cf838d6f27e",
+    "wof:geomhash":"c1168d4741f2ac15605e523495e57442",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564733,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Mean Chey",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/473/5/1108564735.geojson
+++ b/data/110/856/473/5/1108564735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127082,
-    "geom:area_square_m":1537719986.592506,
+    "geom:area_square_m":1537720585.768774,
     "geom:bbox":"105.957778,11.669341,106.467042,12.152009",
     "geom:latitude":11.882121,
     "geom:longitude":106.203448,
@@ -104,9 +104,10 @@
         "hasc:id":"KH.TB.MM",
         "wd:id":"Q2221903"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062722,
-    "wof:geomhash":"90e415e7365cfd4a21f1f5144b4afcea",
+    "wof:geomhash":"fd7d264320bb321145c312681f4d1759",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108564735,
-    "wof:lastmodified":1690938118,
+    "wof:lastmodified":1695886192,
     "wof:name":"Memot",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/110/856/473/7/1108564737.geojson
+++ b/data/110/856/473/7/1108564737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067178,
-    "geom:area_square_m":807863592.020056,
+    "geom:area_square_m":807863717.83848,
     "geom:bbox":"102.686997,13.359412,103.260744,13.570945",
     "geom:latitude":13.457173,
     "geom:longitude":102.989118,
@@ -107,9 +107,10 @@
         "hasc:id":"KH.OM.MB",
         "wd:id":"Q1945748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062725,
-    "wof:geomhash":"2ae90aee0cd956d878c68f07b05c42ee",
+    "wof:geomhash":"db4516b78de2d86beb9956b6a133aff2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108564737,
-    "wof:lastmodified":1690938118,
+    "wof:lastmodified":1695886192,
     "wof:name":"Mongkol Borei",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/110/856/473/9/1108564739.geojson
+++ b/data/110/856/473/9/1108564739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131594,
-    "geom:area_square_m":1586396252.519002,
+    "geom:area_square_m":1586396758.664398,
     "geom:bbox":"103.30386,12.60353,103.918881,13.125431",
     "geom:latitude":12.856263,
     "geom:longitude":103.555209,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062726,
-    "wof:geomhash":"61e319a0f1608d9f8527fa4137884ec4",
+    "wof:geomhash":"25b7d8b564c07b12d5b232c1f1448740",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108564739,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Moung Ruessei",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/474/1/1108564741.geojson
+++ b/data/110/856/474/1/1108564741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016452,
-    "geom:area_square_m":199158735.50652,
+    "geom:area_square_m":199158719.034852,
     "geom:bbox":"104.858382,11.670636,105.018674,11.880619",
     "geom:latitude":11.772147,
     "geom:longitude":104.938769,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KN.MK",
         "wd:id":"Q4930627"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062728,
-    "wof:geomhash":"9d26159263c60a083fd8c8a3b7e1472d",
+    "wof:geomhash":"0c8ac97f4e440659b4487783c3b7dcf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564741,
-    "wof:lastmodified":1690938118,
+    "wof:lastmodified":1695886192,
     "wof:name":"Mukh Kampul",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/474/3/1108564743.geojson
+++ b/data/110/856/474/3/1108564743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046836,
-    "geom:area_square_m":562312736.756525,
+    "geom:area_square_m":562312736.756556,
     "geom:bbox":"106.871138704,13.7201960986,107.166072246,13.9757708361",
     "geom:latitude":13.841857,
     "geom:longitude":107.034971,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.RO.OC",
         "wd:id":"Q4930108"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062731,
-    "wof:geomhash":"10ae9b3c377eef251a19c037e33cf9b6",
+    "wof:geomhash":"e54d24e8d5c894be92d48be32fa96463",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564743,
-    "wof:lastmodified":1566727457,
+    "wof:lastmodified":1695886192,
     "wof:name":"Ou Chum",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/474/5/1108564745.geojson
+++ b/data/110/856/474/5/1108564745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102324,
-    "geom:area_square_m":1235947095.188772,
+    "geom:area_square_m":1235947486.751913,
     "geom:bbox":"106.815767,12.131628,107.547997,12.527825",
     "geom:latitude":12.356384,
     "geom:longitude":107.171104,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.MK.OR",
         "wd:id":"Q4929265"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062733,
-    "wof:geomhash":"2e1617c7a1e426432f612f0f34ed44e2",
+    "wof:geomhash":"5aae779c337b3b322e4b5de225832689",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564745,
-    "wof:lastmodified":1690938119,
+    "wof:lastmodified":1695886192,
     "wof:name":"Ou Reang",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/110/856/474/7/1108564747.geojson
+++ b/data/110/856/474/7/1108564747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139141,
-    "geom:area_square_m":1672649007.382767,
+    "geom:area_square_m":1672649007.381948,
     "geom:bbox":"107.263853444,13.2769969223,107.627687,13.8360230434",
     "geom:latitude":13.544434,
     "geom:longitude":107.447767,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.RO.OY",
         "wd:id":"Q4930220"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062735,
-    "wof:geomhash":"d62db3e877ed0f6f9b66803b3cd26d4b",
+    "wof:geomhash":"b36298d804a8cd9bf1c8072d61a2891c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108564747,
-    "wof:lastmodified":1566727457,
+    "wof:lastmodified":1695886192,
     "wof:name":"Ou Ya Dav",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/110/856/475/1/1108564751.geojson
+++ b/data/110/856/475/1/1108564751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022381,
-    "geom:area_square_m":268932682.128378,
+    "geom:area_square_m":268932682.128405,
     "geom:bbox":"102.547946,13.5608690044,102.757876574,13.7385885317",
     "geom:latitude":13.649277,
     "geom:longitude":102.659938,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.OM.OC",
         "wd:id":"Q4929257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062737,
-    "wof:geomhash":"563e2dd542b52c7677d3ceade0cb95b3",
+    "wof:geomhash":"b9447698f9f02f232b3e95e0923e3c39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564751,
-    "wof:lastmodified":1566727456,
+    "wof:lastmodified":1695886191,
     "wof:name":"Paoy Paet",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/110/856/475/3/1108564753.geojson
+++ b/data/110/856/475/3/1108564753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040174,
-    "geom:area_square_m":486494324.456201,
+    "geom:area_square_m":486494144.533136,
     "geom:bbox":"105.103667,11.557087,105.402529,11.79828",
     "geom:latitude":11.669087,
     "geom:longitude":105.243015,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.PY.PG",
         "wd:id":"Q4930230"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062738,
-    "wof:geomhash":"8ab16c96a27e20efe368618bf83758e3",
+    "wof:geomhash":"0e4fedc91948e4573980e291fb4a02aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564753,
-    "wof:lastmodified":1690938116,
+    "wof:lastmodified":1695886191,
     "wof:name":"Pea Reang",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/475/5/1108564755.geojson
+++ b/data/110/856/475/5/1108564755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036046,
-    "geom:area_square_m":437505214.16769,
+    "geom:area_square_m":437505089.317719,
     "geom:bbox":"105.183151,10.859526,105.380673,11.226534",
     "geom:latitude":11.011685,
     "geom:longitude":105.268944,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PY.PC",
         "wd:id":"Q4929420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062740,
-    "wof:geomhash":"875703a53cc2e2abb1a129c2eef4bf44",
+    "wof:geomhash":"590cb77e63164947783ef71558a7455b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564755,
-    "wof:lastmodified":1690938116,
+    "wof:lastmodified":1695886191,
     "wof:name":"Peam Chor",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/475/7/1108564757.geojson
+++ b/data/110/856/475/7/1108564757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314933,
-    "geom:area_square_m":3798789649.154427,
+    "geom:area_square_m":3798789649.154345,
     "geom:bbox":"106.484244673,12.3716951535,107.589815,12.9128264702",
     "geom:latitude":12.709458,
     "geom:longitude":107.13198,
@@ -84,9 +84,10 @@
         "hasc:id":"KH.MK.PC",
         "wd:id":"Q7158696"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062742,
-    "wof:geomhash":"07e3b9ba38c1154fd4a1279317c4df2c",
+    "wof:geomhash":"834ba668e66b16b975278685868b5aac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108564757,
-    "wof:lastmodified":1566727456,
+    "wof:lastmodified":1695886191,
     "wof:name":"Pech Chreada",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/110/856/475/9/1108564759.geojson
+++ b/data/110/856/475/9/1108564759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.283349,
-    "geom:area_square_m":3424809304.075264,
+    "geom:area_square_m":3424809304.075581,
     "geom:bbox":"103.469761352,11.8397632828,104.201818545,12.5171356619",
     "geom:latitude":12.178412,
     "geom:longitude":103.823278,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.PO.PK",
         "wd:id":"Q4929393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062744,
-    "wof:geomhash":"ebacd5af7a3cbe08e9dd71cf557f027e",
+    "wof:geomhash":"f803d3f5fc8d43df808ffa0555eee800",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564759,
-    "wof:lastmodified":1566727456,
+    "wof:lastmodified":1695886191,
     "wof:name":"Phnum Kravanh",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/110/856/476/1/1108564761.geojson
+++ b/data/110/856/476/1/1108564761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054213,
-    "geom:area_square_m":652428491.051854,
+    "geom:area_square_m":652428368.864687,
     "geom:bbox":"102.345097,13.194165,102.691892,13.386121",
     "geom:latitude":13.281558,
     "geom:longitude":102.523476,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062745,
-    "wof:geomhash":"1c57e2d26eb6898c9eaaf2567d2d2060",
+    "wof:geomhash":"83359288d7862551ad7302278f9fa166",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108564761,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Phnum Proek",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/476/3/1108564763.geojson
+++ b/data/110/856/476/3/1108564763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063776,
-    "geom:area_square_m":765766387.872199,
+    "geom:area_square_m":765766387.87206,
     "geom:bbox":"103.159893055,13.6575140498,103.441360737,14.0234504076",
     "geom:latitude":13.822201,
     "geom:longitude":103.317774,
@@ -95,9 +95,10 @@
         "hasc:id":"KH.OM.PS",
         "wd:id":"Q3306393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062747,
-    "wof:geomhash":"999e1f86bc096454ef9ed918459b9804",
+    "wof:geomhash":"90b01642866927dd9f7be953018feb76",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108564763,
-    "wof:lastmodified":1566727452,
+    "wof:lastmodified":1695886187,
     "wof:name":"Phnum Srok",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/110/856/476/5/1108564765.geojson
+++ b/data/110/856/476/5/1108564765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136274,
-    "geom:area_square_m":1652319930.803411,
+    "geom:area_square_m":1652319819.232803,
     "geom:bbox":"104.022745,11.09,104.466318,11.527779",
     "geom:latitude":11.311042,
     "geom:longitude":104.236786,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KS.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062748,
-    "wof:geomhash":"a5766874868be6346cc23e97b20b0b41",
+    "wof:geomhash":"5f7ecc969ece463a5c0665f532f8d2cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564765,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Phnum Sruoch",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/476/9/1108564769.geojson
+++ b/data/110/856/476/9/1108564769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009717,
-    "geom:area_square_m":117677008.799948,
+    "geom:area_square_m":117677221.977465,
     "geom:bbox":"104.733621,11.578882,104.866443,11.716764",
     "geom:latitude":11.640227,
     "geom:longitude":104.8008,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062751,
-    "wof:geomhash":"57a83b17f065051341419e97090ecbec",
+    "wof:geomhash":"e3c99fadd99269b8f0f35e26c08c0fc5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108564769,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Praek Pnov",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/477/1/1108564771.geojson
+++ b/data/110/856/477/1/1108564771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000296,
-    "geom:area_square_m":3580619.270656,
+    "geom:area_square_m":3580611.505587,
     "geom:bbox":"104.903813,11.552123,104.925463,11.571465",
     "geom:latitude":11.561552,
     "geom:longitude":104.914015,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062753,
-    "wof:geomhash":"245556338be1426e9d3fe7d5c7cc8b22",
+    "wof:geomhash":"8da02e986e3cf1c44e1688bf1d5ec378",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564771,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Prampir Meakkakra",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/477/3/1108564773.geojson
+++ b/data/110/856/477/3/1108564773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115119,
-    "geom:area_square_m":1386532145.324597,
+    "geom:area_square_m":1386531754.529479,
     "geom:bbox":"104.619232,12.838822,105.078802,13.313839",
     "geom:latitude":13.080231,
     "geom:longitude":104.835702,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KT.PB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062756,
-    "wof:geomhash":"7afc062201dda35a3d248b5b0d46d58a",
+    "wof:geomhash":"7ec96505ef3d5120d1d6b0858a244d85",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564773,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Prasat Ballangk",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/110/856/477/5/1108564775.geojson
+++ b/data/110/856/477/5/1108564775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039983,
-    "geom:area_square_m":485169855.313267,
+    "geom:area_square_m":485169855.313318,
     "geom:bbox":"105.256457867,10.9057288865,105.468676567,11.2536394138",
     "geom:latitude":11.087432,
     "geom:longitude":105.376329,
@@ -80,9 +80,10 @@
         "hasc:id":"KH.PY.PS",
         "wd:id":"Q4930046"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062759,
-    "wof:geomhash":"f0a355261e99c547cc9d013533048e06",
+    "wof:geomhash":"f377a29b575485ae07e7248925e502bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108564775,
-    "wof:lastmodified":1566727452,
+    "wof:lastmodified":1695886187,
     "wof:name":"Preah Sdach",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/477/7/1108564777.geojson
+++ b/data/110/856/477/7/1108564777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016069,
-    "geom:area_square_m":195270547.312316,
+    "geom:area_square_m":195270375.652346,
     "geom:bbox":"103.126198,10.274583,103.592926,10.779583",
     "geom:latitude":10.651619,
     "geom:longitude":103.377566,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KK.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062761,
-    "wof:geomhash":"5a056ce1cb638744ad4e4b82d5ca41fb",
+    "wof:geomhash":"f248af1b8fa7d92aaf6505da997aca25",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108564777,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886752,
     "wof:name":"Preah Sihanouk",
     "wof:parent_id":85673101,
     "wof:placetype":"county",

--- a/data/110/856/477/9/1108564779.geojson
+++ b/data/110/856/477/9/1108564779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024002,
-    "geom:area_square_m":288296132.342796,
+    "geom:area_square_m":288296132.34271,
     "geom:bbox":"104.87120989,13.6304772815,105.08485151,13.8418222465",
     "geom:latitude":13.737051,
     "geom:longitude":104.980752,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PH.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062762,
-    "wof:geomhash":"cd02910da0f9bd688320991d531a0941",
+    "wof:geomhash":"1fd956b71624de9c317e788ed3ed62d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108564779,
-    "wof:lastmodified":1566727452,
+    "wof:lastmodified":1695886187,
     "wof:name":"Preah Vihear",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/478/1/1108564781.geojson
+++ b/data/110/856/478/1/1108564781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114653,
-    "geom:area_square_m":1384236771.00331,
+    "geom:area_square_m":1384237129.027727,
     "geom:bbox":"105.695132,12.25491,106.045137,12.722438",
     "geom:latitude":12.474014,
     "geom:longitude":105.875675,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KH.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062764,
-    "wof:geomhash":"c3ca0a095a6c91fc33b75d91284c6f24",
+    "wof:geomhash":"cbceb33b46124ba446e670021680070b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564781,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Prek Prasab",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/110/856/478/3/1108564783.geojson
+++ b/data/110/856/478/3/1108564783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037161,
-    "geom:area_square_m":449309911.969744,
+    "geom:area_square_m":449309911.969735,
     "geom:bbox":"105.102722227,11.9918579307,105.355421279,12.2169396401",
     "geom:latitude":12.087896,
     "geom:longitude":105.227599,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KC.PC",
         "wd:id":"Q4929127"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062765,
-    "wof:geomhash":"e3274f6254e7b5ce27175444b77fb2a1",
+    "wof:geomhash":"d2ba870fe104697ab1129e9acb7d8458",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564783,
-    "wof:lastmodified":1566727451,
+    "wof:lastmodified":1695886186,
     "wof:name":"Prey Chhor",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/478/7/1108564787.geojson
+++ b/data/110/856/478/7/1108564787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022255,
-    "geom:area_square_m":269996406.311775,
+    "geom:area_square_m":269996406.311763,
     "geom:bbox":"104.834935385,11.0731321076,105.023276328,11.2395998788",
     "geom:latitude":11.145531,
     "geom:longitude":104.930095,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.TA.PK",
         "wd:id":"Q4929404"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062767,
-    "wof:geomhash":"8eba9209948d7a69b943408600c4de5a",
+    "wof:geomhash":"5a9bd78e2cdbae739324de17a691f416",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564787,
-    "wof:lastmodified":1566727451,
+    "wof:lastmodified":1695886187,
     "wof:name":"Prey Kabbas",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/478/9/1108564789.geojson
+++ b/data/110/856/478/9/1108564789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005778,
-    "geom:area_square_m":70017517.704924,
+    "geom:area_square_m":70017586.985461,
     "geom:bbox":"105.286001,11.430135,105.395175,11.523868",
     "geom:latitude":11.477568,
     "geom:longitude":105.3358,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PY.PV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062770,
-    "wof:geomhash":"ae635f324e2e4e0ab9ef6c9a06c34f58",
+    "wof:geomhash":"25829bc9a0e9f2b034dc41403ec527a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108564789,
-    "wof:lastmodified":1636500703,
+    "wof:lastmodified":1695886764,
     "wof:name":"Prey Veng",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/479/1/1108564791.geojson
+++ b/data/110/856/479/1/1108564791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022511,
-    "geom:area_square_m":272735008.467336,
+    "geom:area_square_m":272735008.467347,
     "geom:bbox":"105.123461176,11.426977461,105.39817485,11.614790605",
     "geom:latitude":11.536254,
     "geom:longitude":105.25967,
@@ -74,9 +74,10 @@
         "hasc:id":"KH.PY.KL",
         "wd:id":"Q4930117"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062772,
-    "wof:geomhash":"ffcbb918ab1935f51dd79d23c5835603",
+    "wof:geomhash":"9bcbf046480ebd54f58ee2e754d60361",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108564791,
-    "wof:lastmodified":1566727454,
+    "wof:lastmodified":1695886189,
     "wof:name":"Pur Rieng",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/479/3/1108564793.geojson
+++ b/data/110/856/479/3/1108564793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012136,
-    "geom:area_square_m":147038613.931151,
+    "geom:area_square_m":147038613.93112,
     "geom:bbox":"104.720740775,11.454999229,104.874112863,11.6095404",
     "geom:latitude":11.535775,
     "geom:longitude":104.793111,
@@ -71,9 +71,10 @@
         "hasc:id":"KH.KN.AS",
         "wd:id":"Q4763307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062773,
-    "wof:geomhash":"d330c57ff54c1439649d74a389b48f19",
+    "wof:geomhash":"38de61211fcfa66dfdafb0584fd3f88e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108564793,
-    "wof:lastmodified":1566727454,
+    "wof:lastmodified":1695886189,
     "wof:name":"Pur SenChey",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/479/5/1108564795.geojson
+++ b/data/110/856/479/5/1108564795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029506,
-    "geom:area_square_m":356241892.709733,
+    "geom:area_square_m":356241737.825005,
     "geom:bbox":"103.786477,12.352573,104.01797,12.569025",
     "geom:latitude":12.472791,
     "geom:longitude":103.915051,
@@ -81,9 +81,10 @@
         "hasc:id":"KH.PO.SM",
         "wd:id":"Q4929515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062775,
-    "wof:geomhash":"6d26179692780e537a8d95ade14bae4d",
+    "wof:geomhash":"232555eed9b78668f643ec84508a0672",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108564795,
-    "wof:lastmodified":1690938112,
+    "wof:lastmodified":1695886764,
     "wof:name":"Pursat",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/110/856/479/7/1108564797.geojson
+++ b/data/110/856/479/7/1108564797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062964,
-    "geom:area_square_m":763133963.137336,
+    "geom:area_square_m":763134053.640662,
     "geom:bbox":"105.650278,11.262699,105.904,11.602052",
     "geom:latitude":11.425382,
     "geom:longitude":105.77071,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062777,
-    "wof:geomhash":"a22d22b300459cc1c36490436b7e045b",
+    "wof:geomhash":"04dbf5b456606a3ead86f4629e10b43e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564797,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Romeas Haek",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/479/9/1108564799.geojson
+++ b/data/110/856/479/9/1108564799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065979,
-    "geom:area_square_m":795353084.827277,
+    "geom:area_square_m":795353085.420941,
     "geom:bbox":"102.71133,12.731855,103.043651,13.091438",
     "geom:latitude":12.869627,
     "geom:longitude":102.874743,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.RM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062778,
-    "wof:geomhash":"1803ce9c772a77e79323c0c77eecf97e",
+    "wof:geomhash":"8108c72788974f91ad5efa88045a9d2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564799,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Rotonak Mondol",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/480/1/1108564801.geojson
+++ b/data/110/856/480/1/1108564801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.182022,
-    "geom:area_square_m":2189894982.616154,
+    "geom:area_square_m":2189894982.614833,
     "geom:bbox":"104.802229008,13.0544349139,105.539953904,13.6350641396",
     "geom:latitude":13.351848,
     "geom:longitude":105.09641,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.PH.RV",
         "wd:id":"Q4929033"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062780,
-    "wof:geomhash":"1dce9971d57994b1ddb74088ec4f0ae8",
+    "wof:geomhash":"5c26c0583c9dfd7aabffcb1ba7206ddc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564801,
-    "wof:lastmodified":1566727458,
+    "wof:lastmodified":1695886194,
     "wof:name":"Rovieng",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/480/5/1108564805.geojson
+++ b/data/110/856/480/5/1108564805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040081,
-    "geom:area_square_m":483698154.439079,
+    "geom:area_square_m":483697793.949742,
     "geom:bbox":"103.235441,12.502234,103.6436,12.6869",
     "geom:latitude":12.588024,
     "geom:longitude":103.444872,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062781,
-    "wof:geomhash":"8ab9555738202d2c2791dc8ac059d402",
+    "wof:geomhash":"44e5b9027c57719dbd0c6c547759709b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108564805,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Rukh Kiri",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/480/7/1108564807.geojson
+++ b/data/110/856/480/7/1108564807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022891,
-    "geom:area_square_m":277638624.422131,
+    "geom:area_square_m":277638809.909298,
     "geom:bbox":"105.716532,11.139835,105.934874,11.298259",
     "geom:latitude":11.224084,
     "geom:longitude":105.827443,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.RD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062783,
-    "wof:geomhash":"4c7b387ffb1ff7edc5f845d6fff93ce0",
+    "wof:geomhash":"3a0be2866d4ec95e1af3f8a977b41d1a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564807,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Rumduol",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/480/9/1108564809.geojson
+++ b/data/110/856/480/9/1108564809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001994,
-    "geom:area_square_m":24149382.883149,
+    "geom:area_square_m":24149446.349964,
     "geom:bbox":"104.855651,11.585166,104.921292,11.660132",
     "geom:latitude":11.619679,
     "geom:longitude":104.894273,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062784,
-    "wof:geomhash":"53943cc5432e5ff43a4a73db5e1154fc",
+    "wof:geomhash":"0a8b00e7c77f287e3e876d636807dbb3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564809,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Russey Keo",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/481/1/1108564811.geojson
+++ b/data/110/856/481/1/1108564811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042793,
-    "geom:area_square_m":518854653.163513,
+    "geom:area_square_m":518854653.023516,
     "geom:bbox":"104.927131,11.170388,105.169604,11.464478",
     "geom:latitude":11.32017,
     "geom:longitude":105.037208,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.KN.SA",
         "wd:id":"Q7387018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062786,
-    "wof:geomhash":"2e98e33a1cb3390da3b1ebafea6bbd43",
+    "wof:geomhash":"6ab95936bf366cb010fad53adaec1287",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564811,
-    "wof:lastmodified":1690938115,
+    "wof:lastmodified":1695886190,
     "wof:name":"S'ang",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/110/856/481/3/1108564813.geojson
+++ b/data/110/856/481/3/1108564813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004384,
-    "geom:area_square_m":53107632.158172,
+    "geom:area_square_m":53107661.359174,
     "geom:bbox":"104.822274,11.5454,104.89565,11.649403",
     "geom:latitude":11.595448,
     "geom:longitude":104.861178,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062788,
-    "wof:geomhash":"72e705904067c601ed378c049fda703f",
+    "wof:geomhash":"37187281fba8a79ab5d5b7dba3047b4d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108564813,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Saensokh",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/481/5/1108564815.geojson
+++ b/data/110/856/481/5/1108564815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042388,
-    "geom:area_square_m":510739966.387791,
+    "geom:area_square_m":510739884.258275,
     "geom:bbox":"102.485557,12.888083,102.755182,13.115057",
     "geom:latitude":12.981576,
     "geom:longitude":102.640453,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PL.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062789,
-    "wof:geomhash":"085bf5f090d637080a8812a8d0cdad80",
+    "wof:geomhash":"5e645ab5c7539412497800adc81425b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564815,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Sala Krau",
     "wof:parent_id":85673037,
     "wof:placetype":"county",

--- a/data/110/856/481/7/1108564817.geojson
+++ b/data/110/856/481/7/1108564817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037853,
-    "geom:area_square_m":455278808.632937,
+    "geom:area_square_m":455279055.526573,
     "geom:bbox":"102.354795,13.357524,102.690357,13.479488",
     "geom:latitude":13.418901,
     "geom:longitude":102.527369,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.BA.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062794,
-    "wof:geomhash":"4e9e91f3f4a742558a1f10056e9a83f0",
+    "wof:geomhash":"ac62c80b3944816f558dcc064661d04e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564817,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Sampov Lun",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/481/9/1108564819.geojson
+++ b/data/110/856/481/9/1108564819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060615,
-    "geom:area_square_m":734548966.352085,
+    "geom:area_square_m":734548915.899504,
     "geom:bbox":"104.275589,11.290752,104.67672,11.607727",
     "geom:latitude":11.467083,
     "geom:longitude":104.494875,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KS.SY",
         "wd:id":"Q4929551"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062795,
-    "wof:geomhash":"3b5da6ba8bbf149714ec2e2b2d50b67e",
+    "wof:geomhash":"54f4b5922dcdd023d3f482bf2ab1c1c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564819,
-    "wof:lastmodified":1690938115,
+    "wof:lastmodified":1695886190,
     "wof:name":"Samraong Tong",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/482/3/1108564823.geojson
+++ b/data/110/856/482/3/1108564823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11841,
-    "geom:area_square_m":1419106479.325136,
+    "geom:area_square_m":1419106610.406213,
     "geom:bbox":"103.383765,14.096323,103.836903,14.440413",
     "geom:latitude":14.250586,
     "geom:longitude":103.620941,
@@ -78,9 +78,10 @@
         "hasc:id":"KH.OC.SR",
         "wd:id":"Q7410285"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062797,
-    "wof:geomhash":"d0fe55ab0eb88d7497deb32dab7cce18",
+    "wof:geomhash":"5818425e7d0f754b8650e00bed8f0179",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108564823,
-    "wof:lastmodified":1690938110,
+    "wof:lastmodified":1695886188,
     "wof:name":"Samraong",
     "wof:parent_id":85673033,
     "wof:placetype":"county",

--- a/data/110/856/482/5/1108564825.geojson
+++ b/data/110/856/482/5/1108564825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024446,
-    "geom:area_square_m":296594923.494712,
+    "geom:area_square_m":296594617.607079,
     "geom:bbox":"104.683668,11.037203,104.852746,11.221161",
     "geom:latitude":11.129617,
     "geom:longitude":104.771509,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"KH.OC.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062798,
-    "wof:geomhash":"931a764b9514e283f95073ccf8ed8eac",
+    "wof:geomhash":"14febaa77d01245fb0f6e01f55a7cde9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108564825,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Samraong",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/482/7/1108564827.geojson
+++ b/data/110/856/482/7/1108564827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110617,
-    "geom:area_square_m":1330074032.677673,
+    "geom:area_square_m":1330073935.846692,
     "geom:bbox":"104.564752,13.251518,104.987798,13.725297",
     "geom:latitude":13.487588,
     "geom:longitude":104.781029,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PH.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062801,
-    "wof:geomhash":"39ef72553c645e6eaed3216ffc83ed61",
+    "wof:geomhash":"3ff6c357487f7002adb603770fe22878",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564827,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Sangkum Thmei",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/482/9/1108564829.geojson
+++ b/data/110/856/482/9/1108564829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215046,
-    "geom:area_square_m":2594774091.447181,
+    "geom:area_square_m":2594774005.443048,
     "geom:bbox":"104.816173,12.372531,105.735496,12.809902",
     "geom:latitude":12.626825,
     "geom:longitude":105.337969,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KT.ST",
         "wd:id":"Q4930664"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062803,
-    "wof:geomhash":"cb37afd46f00d4fe3158d3c8955c3d31",
+    "wof:geomhash":"b20b1950c052a187635caa2258ccdd84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564829,
-    "wof:lastmodified":1690938110,
+    "wof:lastmodified":1695886187,
     "wof:name":"Santuk",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/110/856/483/1/1108564831.geojson
+++ b/data/110/856/483/1/1108564831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224953,
-    "geom:area_square_m":2703513964.281502,
+    "geom:area_square_m":2703513633.684064,
     "geom:bbox":"106.023883,13.32208,106.664009,13.890769",
     "geom:latitude":13.606261,
     "geom:longitude":106.358125,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.ST.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062805,
-    "wof:geomhash":"7c00377cbf6b9d8d0ad3f3625f6bab6f",
+    "wof:geomhash":"b97a055b7b0a76c2ece71192a3b34314",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564831,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Sesan",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/110/856/483/3/1108564833.geojson
+++ b/data/110/856/483/3/1108564833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122415,
-    "geom:area_square_m":1473051412.566439,
+    "geom:area_square_m":1473051284.398592,
     "geom:bbox":"105.542066,13.112982,106.125228,13.50909",
     "geom:latitude":13.305878,
     "geom:longitude":105.815005,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.ST.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062807,
-    "wof:geomhash":"f2eeef4ca0deea7849ca3f75d7100f07",
+    "wof:geomhash":"c25bc1e1054796f0d8a6fd7bd137b834",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564833,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Siem Bouk",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/110/856/483/5/1108564835.geojson
+++ b/data/110/856/483/5/1108564835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.382485,
-    "geom:area_square_m":4585460954.94456,
+    "geom:area_square_m":4585460516.198162,
     "geom:bbox":"105.994552,13.833963,106.79,14.593423",
     "geom:latitude":14.175847,
     "geom:longitude":106.422343,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.ST.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062808,
-    "wof:geomhash":"6daf329e6d81c82f3708f36a743fe536",
+    "wof:geomhash":"abd23a9517bdfdc2a44f253028930996",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564835,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886752,
     "wof:name":"Siem Pang",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/110/856/483/7/1108564837.geojson
+++ b/data/110/856/483/7/1108564837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026196,
-    "geom:area_square_m":317108868.698594,
+    "geom:area_square_m":317108864.578014,
     "geom:bbox":"105.231286,11.677353,105.508768,11.868529",
     "geom:latitude":11.77295,
     "geom:longitude":105.362755,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.PY.SK",
         "wd:id":"Q4930028"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062811,
-    "wof:geomhash":"baed76f940745f843e899583a7c1d166",
+    "wof:geomhash":"78bd2fc73a43ad915734a75423441a61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564837,
-    "wof:lastmodified":1690938111,
+    "wof:lastmodified":1695886188,
     "wof:name":"Sithor Kandal",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/484/1/1108564841.geojson
+++ b/data/110/856/484/1/1108564841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.233683,
-    "geom:area_square_m":2824322998.198422,
+    "geom:area_square_m":2824322998.197978,
     "geom:bbox":"106.141667229,11.9493554094,106.801823181,12.5115197289",
     "geom:latitude":12.194823,
     "geom:longitude":106.471857,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.KH.SN",
         "wd:id":"Q4929275"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062812,
-    "wof:geomhash":"dc9ea97465499d1b34a6b76a44560dbc",
+    "wof:geomhash":"fa53eba39c56ee05dc3a8509df654d6c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108564841,
-    "wof:lastmodified":1566727453,
+    "wof:lastmodified":1695886188,
     "wof:name":"Snuol",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/110/856/484/3/1108564843.geojson
+++ b/data/110/856/484/3/1108564843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103176,
-    "geom:area_square_m":1242341061.337793,
+    "geom:area_square_m":1242341704.139691,
     "geom:bbox":"103.927111,12.828362,104.222989,13.492199",
     "geom:latitude":13.147514,
     "geom:longitude":104.0993,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SI.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062814,
-    "wof:geomhash":"a145bd3b8cc9c84ccfce38681346b45a",
+    "wof:geomhash":"32a2a4350059367f6b0fa12b7d298431",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564843,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886753,
     "wof:name":"Soutr Nikom",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/484/5/1108564845.geojson
+++ b/data/110/856/484/5/1108564845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028792,
-    "geom:area_square_m":348448928.14947,
+    "geom:area_square_m":348448724.143747,
     "geom:bbox":"105.042618,11.732076,105.289093,11.951738",
     "geom:latitude":11.835855,
     "geom:longitude":105.166257,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.KC.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062816,
-    "wof:geomhash":"c5d834c954a670c18c4ddbe367952fc8",
+    "wof:geomhash":"c03cd49d7d75f32777f188eeca80c2f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564845,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886753,
     "wof:name":"Srei Santhor",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/484/7/1108564847.geojson
+++ b/data/110/856/484/7/1108564847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046675,
-    "geom:area_square_m":560398306.415054,
+    "geom:area_square_m":560398413.234424,
     "geom:bbox":"103.421032,13.692244,103.731211,13.96943",
     "geom:latitude":13.837236,
     "geom:longitude":103.563619,
@@ -83,9 +83,10 @@
         "hasc:id":"KH.SI.SS",
         "wd:id":"Q4929593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062818,
-    "wof:geomhash":"b23af36833e7c4c75d0c1831fa41a40a",
+    "wof:geomhash":"7e318d237ba873638db638b49ffca8ee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108564847,
-    "wof:lastmodified":1690938111,
+    "wof:lastmodified":1695886188,
     "wof:name":"Srei Snam",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/110/856/484/9/1108564849.geojson
+++ b/data/110/856/484/9/1108564849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163322,
-    "geom:area_square_m":1968497855.729691,
+    "geom:area_square_m":1968498130.803638,
     "geom:bbox":"104.171101,12.635685,104.71478,13.28119",
     "geom:latitude":12.90446,
     "geom:longitude":104.484548,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KT.SG",
         "wd:id":"Q7620568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062819,
-    "wof:geomhash":"a5b6fe29c660242c47ecdc61317282af",
+    "wof:geomhash":"33f3fb30c5dd476ad97a69680fb57e19",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564849,
-    "wof:lastmodified":1690938111,
+    "wof:lastmodified":1695886188,
     "wof:name":"Stoung",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/110/856/485/1/1108564851.geojson
+++ b/data/110/856/485/1/1108564851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021466,
-    "geom:area_square_m":260757254.038413,
+    "geom:area_square_m":260757254.038324,
     "geom:bbox":"103.547058105,10.6509765028,103.812356358,10.9410454314",
     "geom:latitude":10.769398,
     "geom:longitude":103.683483,
@@ -87,9 +87,10 @@
         "hasc:id":"KH.KA.SH",
         "wd:id":"Q4929384"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062821,
-    "wof:geomhash":"a65d72e9f99888b90b3aa061f198b413",
+    "wof:geomhash":"0a7f68a1c3b9ea906d2c6720094acf48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108564851,
-    "wof:lastmodified":1566727451,
+    "wof:lastmodified":1695886187,
     "wof:name":"Stueng Hav",
     "wof:parent_id":85673101,
     "wof:placetype":"county",

--- a/data/110/856/485/3/1108564853.geojson
+++ b/data/110/856/485/3/1108564853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090936,
-    "geom:area_square_m":1098390419.986513,
+    "geom:area_square_m":1098390850.654666,
     "geom:bbox":"105.361086,12.164436,105.777688,12.501578",
     "geom:latitude":12.358085,
     "geom:longitude":105.558683,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KC.ST",
         "wd:id":"Q4929112"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062824,
-    "wof:geomhash":"548640342188df8e80b8a89dbca28f98",
+    "wof:geomhash":"d820ed740e711e7565f1d7ced916c2b0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564853,
-    "wof:lastmodified":1690938109,
+    "wof:lastmodified":1695886187,
     "wof:name":"Stueng Trang",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/110/856/485/5/1108564855.geojson
+++ b/data/110/856/485/5/1108564855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009249,
-    "geom:area_square_m":111894068.068313,
+    "geom:area_square_m":111894162.058162,
     "geom:bbox":"105.618296,11.862559,105.720908,11.998659",
     "geom:latitude":11.93402,
     "geom:longitude":105.669474,
@@ -92,9 +92,10 @@
         "hasc:id":"KH.KM.TK",
         "wd:id":"Q7641860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062825,
-    "wof:geomhash":"ff77ea9979fc2aff7aa6fcbb03aa1bf1",
+    "wof:geomhash":"d346a8dd7a2429456fb39389ebbdf0c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108564855,
-    "wof:lastmodified":1690938110,
+    "wof:lastmodified":1695886187,
     "wof:name":"Suong",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/856/485/9/1108564859.geojson
+++ b/data/110/856/485/9/1108564859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03914,
-    "geom:area_square_m":474231386.316831,
+    "geom:area_square_m":474231191.775016,
     "geom:bbox":"105.339878,11.355769,105.591746,11.650927",
     "geom:latitude":11.515934,
     "geom:longitude":105.457067,
@@ -66,9 +66,10 @@
         "hasc:id":"KH.PY.PV",
         "wd:id":"Q4930093"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062827,
-    "wof:geomhash":"4b22bf1b2b58d5a710b4ca4bd34a20bb",
+    "wof:geomhash":"0e730301869a417477cfef426058a016",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108564859,
-    "wof:lastmodified":1690938109,
+    "wof:lastmodified":1695886187,
     "wof:name":"Svay Antor",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/110/856/486/1/1108564861.geojson
+++ b/data/110/856/486/1/1108564861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042648,
-    "geom:area_square_m":517463588.193974,
+    "geom:area_square_m":517463636.70433,
     "geom:bbox":"105.580698,10.973176,105.855648,11.272548",
     "geom:latitude":11.111105,
     "geom:longitude":105.695132,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062829,
-    "wof:geomhash":"186a2e68204bd4552cc845ae2ee3d039",
+    "wof:geomhash":"1203713a094e3d9f2ddf381a58953cd5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564861,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886753,
     "wof:name":"Svay Chrum",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/486/3/1108564863.geojson
+++ b/data/110/856/486/3/1108564863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008569,
-    "geom:area_square_m":103978704.869599,
+    "geom:area_square_m":103978629.642401,
     "geom:bbox":"105.736802,11.025238,105.889775,11.156911",
     "geom:latitude":11.095251,
     "geom:longitude":105.809745,
@@ -82,9 +82,10 @@
         "hasc:id":"KH.SR.SR",
         "wd:id":"Q4929043"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062832,
-    "wof:geomhash":"3d1dc520ef6f286aaf4bb4903145fe47",
+    "wof:geomhash":"aaaf226a132bc0e64fb6894913f15fe2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108564863,
-    "wof:lastmodified":1690938117,
+    "wof:lastmodified":1695886765,
     "wof:name":"Svay Rieng",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/486/5/1108564865.geojson
+++ b/data/110/856/486/5/1108564865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027501,
-    "geom:area_square_m":333688924.406515,
+    "geom:area_square_m":333688878.831439,
     "geom:bbox":"105.833615,10.967706,106.082788,11.212194",
     "geom:latitude":11.107606,
     "geom:longitude":105.942049,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.SR.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062834,
-    "wof:geomhash":"5dd28451d57f7db976922f4b0ed62d93",
+    "wof:geomhash":"9b9e5a171491572358560849c9c99302",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564865,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886753,
     "wof:name":"Svay Teab",
     "wof:parent_id":85673105,
     "wof:placetype":"county",

--- a/data/110/856/486/7/1108564867.geojson
+++ b/data/110/856/486/7/1108564867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053951,
-    "geom:area_square_m":647828112.052449,
+    "geom:area_square_m":647828218.63786,
     "geom:bbox":"104.84091,13.602093,105.18369,13.939369",
     "geom:latitude":13.810335,
     "geom:longitude":105.029134,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PH.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062837,
-    "wof:geomhash":"791c580fe6ed5d4d606b0a523c0722fe",
+    "wof:geomhash":"e4f8a8fe4b1e1f8afe5a680ea0039d1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564867,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886753,
     "wof:name":"Tbaeng Mean Chey",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/110/856/486/9/1108564869.geojson
+++ b/data/110/856/486/9/1108564869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217263,
-    "geom:area_square_m":2610352013.174623,
+    "geom:area_square_m":2610352371.839686,
     "geom:bbox":"105.519569,13.324441,106.046417,13.936797",
     "geom:latitude":13.673978,
     "geom:longitude":105.787696,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.ST.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062840,
-    "wof:geomhash":"9ca7d473f39cf3660714de03d7911a5d",
+    "wof:geomhash":"5411d37ff35a357b2daaec170e9bc4be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564869,
-    "wof:lastmodified":1627522287,
+    "wof:lastmodified":1695886753,
     "wof:name":"Thala Barivat",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/110/856/487/1/1108564871.geojson
+++ b/data/110/856/487/1/1108564871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07141,
-    "geom:area_square_m":859455761.609933,
+    "geom:area_square_m":859455761.609882,
     "geom:bbox":"102.908748792,13.0852886422,103.284145144,13.4127087436",
     "geom:latitude":13.260032,
     "geom:longitude":103.095276,
@@ -96,9 +96,10 @@
         "hasc:id":"KH.BA.TK",
         "wd:id":"Q4930610"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062842,
-    "wof:geomhash":"49f648f0cfc049da6f866f0ebc81e5dc",
+    "wof:geomhash":"8303c32eb658ca658f8c46d4cc3db301",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108564871,
-    "wof:lastmodified":1566727457,
+    "wof:lastmodified":1695886192,
     "wof:name":"Thma Koul",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/110/856/487/3/1108564873.geojson
+++ b/data/110/856/487/3/1108564873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059035,
-    "geom:area_square_m":714765427.578265,
+    "geom:area_square_m":714765080.503886,
     "geom:bbox":"104.225515,11.56,104.6253,11.950573",
     "geom:latitude":11.717816,
     "geom:longitude":104.37644,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.KS.TP",
         "wd:id":"Q4929091"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062844,
-    "wof:geomhash":"d29d3ccbbc81601a4b8b9d04ad5d991c",
+    "wof:geomhash":"b30e66e9e9640123751b5e8cde7b6c63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564873,
-    "wof:lastmodified":1690938118,
+    "wof:lastmodified":1695886192,
     "wof:name":"Thpong",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/110/856/487/7/1108564877.geojson
+++ b/data/110/856/487/7/1108564877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046257,
-    "geom:area_square_m":561444496.861009,
+    "geom:area_square_m":561444513.829772,
     "geom:bbox":"104.409774,10.883566,104.75478,11.132789",
     "geom:latitude":11.011849,
     "geom:longitude":104.605496,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.TA.TK",
         "wd:id":"Q4929370"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062846,
-    "wof:geomhash":"8eba91ef165ebb8bfba6bbb67af004e8",
+    "wof:geomhash":"0597c899d3d7b1c29f01329f473a0718",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564877,
-    "wof:lastmodified":1690938117,
+    "wof:lastmodified":1695886193,
     "wof:name":"Tram Kak",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/487/9/1108564879.geojson
+++ b/data/110/856/487/9/1108564879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124353,
-    "geom:area_square_m":1490877021.256713,
+    "geom:area_square_m":1490877301.462214,
     "geom:bbox":"104.160364,13.928495,104.5069,14.40875",
     "geom:latitude":14.168111,
     "geom:longitude":104.308264,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.OC.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062848,
-    "wof:geomhash":"c8b55f11a999be4c642aa8932b560e0d",
+    "wof:geomhash":"ea9f960f87ac096ce43c3d32d35d53f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564879,
-    "wof:lastmodified":1627522287,
+    "wof:lastmodified":1695886753,
     "wof:name":"Trapeang Prasat",
     "wof:parent_id":85673033,
     "wof:placetype":"county",

--- a/data/110/856/488/1/1108564881.geojson
+++ b/data/110/856/488/1/1108564881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033839,
-    "geom:area_square_m":410903604.361064,
+    "geom:area_square_m":410903639.286647,
     "geom:bbox":"104.675288,10.765446,104.959061,10.995684",
     "geom:latitude":10.883601,
     "geom:longitude":104.802374,
@@ -89,9 +89,10 @@
         "hasc:id":"KH.TA.TG",
         "wd:id":"Q4929468"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062849,
-    "wof:geomhash":"af3958fa7404f581564763c63cec3507",
+    "wof:geomhash":"d939e8eb82044c970314d26336b41413",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108564881,
-    "wof:lastmodified":1690938114,
+    "wof:lastmodified":1695886190,
     "wof:name":"Treang",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/110/856/488/3/1108564883.geojson
+++ b/data/110/856/488/3/1108564883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124567,
-    "geom:area_square_m":1513297961.164071,
+    "geom:area_square_m":1513297677.506256,
     "geom:bbox":"103.916671,10.545389,104.379093,11.024395",
     "geom:latitude":10.742455,
     "geom:longitude":104.107811,
@@ -81,9 +81,10 @@
         "hasc:id":"KH.KP.KP",
         "wd:id":"Q6359357"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062851,
-    "wof:geomhash":"8cabdce6efe2fa650b29a273c708f379",
+    "wof:geomhash":"781064b554e77e10f2017d59c608cdf1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108564883,
-    "wof:lastmodified":1690938114,
+    "wof:lastmodified":1695886190,
     "wof:name":"Tuek Chhou",
     "wof:parent_id":85673093,
     "wof:placetype":"county",

--- a/data/110/856/488/5/1108564885.geojson
+++ b/data/110/856/488/5/1108564885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140359,
-    "geom:area_square_m":1697103785.274275,
+    "geom:area_square_m":1697104234.932559,
     "geom:bbox":"104.171365,11.758323,104.624213,12.353445",
     "geom:latitude":12.083614,
     "geom:longitude":104.377355,
@@ -86,9 +86,10 @@
         "hasc:id":"KH.KG.TP",
         "wd:id":"Q4930078"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062852,
-    "wof:geomhash":"81a0cf34cb7d8e0e13978581f8207836",
+    "wof:geomhash":"2e69cab255323f9289d06186dc0b82b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108564885,
-    "wof:lastmodified":1690938115,
+    "wof:lastmodified":1695886190,
     "wof:name":"Tuek Phos",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/110/856/488/7/1108564887.geojson
+++ b/data/110/856/488/7/1108564887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000591,
-    "geom:area_square_m":7162636.810386,
+    "geom:area_square_m":7162591.023032,
     "geom:bbox":"104.887645,11.549022,104.90708,11.590223",
     "geom:latitude":11.568527,
     "geom:longitude":104.896869,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PP.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062853,
-    "wof:geomhash":"d312fc2278a37c93e4b0ea11d6e2f166",
+    "wof:geomhash":"658221d2def598fdc5d18a9bb60ae5de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108564887,
-    "wof:lastmodified":1627522287,
+    "wof:lastmodified":1695886753,
     "wof:name":"Tuol Kouk",
     "wof:parent_id":85673063,
     "wof:placetype":"county",

--- a/data/110/856/488/9/1108564889.geojson
+++ b/data/110/856/488/9/1108564889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362208,
-    "geom:area_square_m":4376888552.509851,
+    "geom:area_square_m":4376888694.09144,
     "geom:bbox":"102.70351,11.942506,103.53044,12.566733",
     "geom:latitude":12.243463,
     "geom:longitude":103.133725,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"KH.PO.VV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1474062855,
-    "wof:geomhash":"5bcacfc3331058d32e84b79e3cb20a51",
+    "wof:geomhash":"2a1324f563af60effbb183c47967d70c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108564889,
-    "wof:lastmodified":1627522287,
+    "wof:lastmodified":1695886753,
     "wof:name":"Veal Veaeng",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/110/880/431/9/1108804319.geojson
+++ b/data/110/880/431/9/1108804319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.408504,
-    "geom:area_square_m":4942010396.205816,
+    "geom:area_square_m":4942010130.981228,
     "geom:bbox":"105.413103,11.599002,106.467042,12.300543",
     "geom:latitude":11.935411,
     "geom:longitude":105.888756,
@@ -139,12 +139,14 @@
     "wof:concordances":{
         "fips:code":"CB31",
         "hasc:id":"KH.TB",
+        "iso:code":"KH-25",
         "iso:id":"KH-25",
         "wd:id":"Q15623578"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:created":1485293517,
-    "wof:geomhash":"7c799a126d704054bfed5dd164b9fbf8",
+    "wof:geomhash":"a6e868bb5afd281d2f1a88e9272eec84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +161,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938108,
+    "wof:lastmodified":1695884486,
     "wof:name":"Tboung Khmum",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/421/168/305/421168305.geojson
+++ b/data/421/168/305/421168305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0027,
-    "geom:area_square_m":32719398.604802,
+    "geom:area_square_m":32719332.55578,
     "geom:bbox":"104.917975,11.419137,104.972412,11.494032",
     "geom:latitude":11.455532,
     "geom:longitude":104.94292,
@@ -170,12 +170,13 @@
         "qs_pg:id":1091007,
         "wd:id":"Q1948407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008761,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2642724da8e244f4aa82c5dbc590fd7",
+    "wof:geomhash":"c5c928453b81f0ee5ec465c1bcc98ca6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421168305,
-    "wof:lastmodified":1690938125,
+    "wof:lastmodified":1695886785,
     "wof:name":"Ta Khmau",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/169/333/421169333.geojson
+++ b/data/421/169/333/421169333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13021,
-    "geom:area_square_m":1570444541.947451,
+    "geom:area_square_m":1570444573.757547,
     "geom:bbox":"104.354351,12.517245,105.032275,12.98482",
     "geom:latitude":12.738271,
     "geom:longitude":104.710773,
@@ -121,12 +121,13 @@
         "wd:id":"Q4930103",
         "wk:page":"Kampong Svay District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008805,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1b799df416746074453b44187cbd6fc",
+    "wof:geomhash":"ad87f2750562474a5d7804e9d7721636",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421169333,
-    "wof:lastmodified":1690938126,
+    "wof:lastmodified":1695886785,
     "wof:name":"Kampong Svay",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/170/109/421170109.geojson
+++ b/data/421/170/109/421170109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048122,
-    "geom:area_square_m":580282077.315787,
+    "geom:area_square_m":580282341.831234,
     "geom:bbox":"102.497282,12.661085,102.755952,12.892302",
     "geom:latitude":12.788209,
     "geom:longitude":102.625949,
@@ -127,12 +127,13 @@
         "qs_pg:id":774748,
         "wd:id":"Q7124773"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008837,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"482571e3ead8082a4ba551bded3c179e",
+    "wof:geomhash":"cb427fd11c475b7de37434ffffd73897",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421170109,
-    "wof:lastmodified":1690938132,
+    "wof:lastmodified":1695886786,
     "wof:name":"Pailin",
     "wof:parent_id":85673037,
     "wof:placetype":"county",

--- a/data/421/170/329/421170329.geojson
+++ b/data/421/170/329/421170329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02258,
-    "geom:area_square_m":271357985.948467,
+    "geom:area_square_m":271357900.702173,
     "geom:bbox":"102.870447,13.511221,103.083094,13.716706",
     "geom:latitude":13.61301,
     "geom:longitude":102.967086,
@@ -116,12 +116,13 @@
         "qs_pg:id":239150,
         "wd:id":"Q4929174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008848,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1071a618dfaca674bbacb9445b0cef17",
+    "wof:geomhash":"29a0aae0dae83c59b011189f23444663",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421170329,
-    "wof:lastmodified":1690938133,
+    "wof:lastmodified":1695886786,
     "wof:name":"Serei Saophoan",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/171/409/421171409.geojson
+++ b/data/421/171/409/421171409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042442,
-    "geom:area_square_m":510828510.829376,
+    "geom:area_square_m":510828341.263203,
     "geom:bbox":"103.875076,13.046235,104.079176,13.447767",
     "geom:latitude":13.249977,
     "geom:longitude":103.972211,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.SI.PB",
         "qs_pg:id":1249425
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008892,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db76ec8afa4e41c9b86ee24827b4eea3",
+    "wof:geomhash":"c06173cc1dcbb087363b5a3c19e2ac9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421171409,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Prasat Bakong",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/171/545/421171545.geojson
+++ b/data/421/171/545/421171545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009746,
-    "geom:area_square_m":117382202.358069,
+    "geom:area_square_m":117382200.225919,
     "geom:bbox":"103.080901,13.029848,103.230262,13.159221",
     "geom:latitude":13.086786,
     "geom:longitude":103.164918,
@@ -285,12 +285,13 @@
         "qs_pg:id":483437,
         "wd:id":"Q748336"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008897,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d74fee54f0e8df1878f1890bd733b918",
+    "wof:geomhash":"9fb4824fd18142cf08cb52a91132080f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -300,7 +301,7 @@
         }
     ],
     "wof:id":421171545,
-    "wof:lastmodified":1690938134,
+    "wof:lastmodified":1695886786,
     "wof:name":"Battambang",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/172/391/421172391.geojson
+++ b/data/421/172/391/421172391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098775,
-    "geom:area_square_m":1188934521.858152,
+    "geom:area_square_m":1188934710.25729,
     "geom:bbox":"103.156414,13.105106,103.812826,13.38657",
     "geom:latitude":13.234821,
     "geom:longitude":103.467963,
@@ -114,12 +114,13 @@
         "qs_pg:id":1308611,
         "wd:id":"Q4930600"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459008939,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ed3f764d4eac1f20b477168df9f98f6c",
+    "wof:geomhash":"9041da5d55a7edb35e551245178545ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421172391,
-    "wof:lastmodified":1690938130,
+    "wof:lastmodified":1695886786,
     "wof:name":"Aek Phnum",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/177/919/421177919.geojson
+++ b/data/421/177/919/421177919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028285,
-    "geom:area_square_m":342345539.104805,
+    "geom:area_square_m":342345544.223571,
     "geom:bbox":"105.413103,11.740672,105.680511,11.914805",
     "geom:latitude":11.812562,
     "geom:longitude":105.539772,
@@ -113,12 +113,13 @@
         "qs_pg:id":9952,
         "wd:id":"Q4930654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009165,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83660538f411a730bcf5f21ca1aee8b6",
+    "wof:geomhash":"90013628b08aa4dd0c1f87fc110002d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421177919,
-    "wof:lastmodified":1690938133,
+    "wof:lastmodified":1695886786,
     "wof:name":"Ou Reang Ov",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/177/965/421177965.geojson
+++ b/data/421/177/965/421177965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043679,
-    "geom:area_square_m":528938427.231274,
+    "geom:area_square_m":528938427.231314,
     "geom:bbox":"104.420238101,11.5512059574,104.753082123,11.8279427572",
     "geom:latitude":11.668923,
     "geom:longitude":104.612517,
@@ -113,12 +113,13 @@
         "qs_pg:id":19972,
         "wd:id":"Q4929250"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009166,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97623f38957c8acc4f24a80ef7c4199c",
+    "wof:geomhash":"316825c808e8818a41448f377bf11b47",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421177965,
-    "wof:lastmodified":1582346020,
+    "wof:lastmodified":1695886786,
     "wof:name":"Odongk",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/421/180/491/421180491.geojson
+++ b/data/421/180/491/421180491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030611,
-    "geom:area_square_m":369365864.875351,
+    "geom:area_square_m":369365788.497132,
     "geom:bbox":"104.747034,12.519644,104.954305,12.74112",
     "geom:latitude":12.617602,
     "geom:longitude":104.855834,
@@ -111,12 +111,13 @@
         "wd:id":"Q4930194",
         "wk:page":"Stueng Saen District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009261,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35df27542f11630876d68fa1c125e5e0",
+    "wof:geomhash":"90c41390e9a2913decf33dba9ed348e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421180491,
-    "wof:lastmodified":1690938128,
+    "wof:lastmodified":1695886785,
     "wof:name":"Stueng Saen",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/181/961/421181961.geojson
+++ b/data/421/181/961/421181961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06799,
-    "geom:area_square_m":816390690.703203,
+    "geom:area_square_m":816390690.703263,
     "geom:bbox":"102.742999332,13.6974404774,103.232712082,13.9386998458",
     "geom:latitude":13.815407,
     "geom:longitude":102.95225,
@@ -116,12 +116,13 @@
         "qs_pg:id":527122,
         "wd:id":"Q4929021"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009314,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b485451fade13e19fb0025b84edda29a",
+    "wof:geomhash":"171c479ef0257b2da4b116e03c1d027c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421181961,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Svay Chek",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/182/521/421182521.geojson
+++ b/data/421/182/521/421182521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062165,
-    "geom:area_square_m":749390440.075741,
+    "geom:area_square_m":749390474.340879,
     "geom:bbox":"105.000107,12.703816,105.298044,13.021863",
     "geom:latitude":12.864726,
     "geom:longitude":105.141322,
@@ -111,12 +111,13 @@
         "qs_pg:id":918097,
         "wd:id":"Q4930593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009333,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ac93f1c16b12f259d6fe5be86c9aca1",
+    "wof:geomhash":"75becf62fe058955a8f7525db80dca1b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421182521,
-    "wof:lastmodified":1690938134,
+    "wof:lastmodified":1695886787,
     "wof:name":"Prasat Sambour",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/183/117/421183117.geojson
+++ b/data/421/183/117/421183117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18669,
-    "geom:area_square_m":2263655303.794017,
+    "geom:area_square_m":2263655631.302244,
     "geom:bbox":"103.536178,10.896013,104.066593,11.617964",
     "geom:latitude":11.305255,
     "geom:longitude":103.766342,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.KK.SA",
         "qs_pg:id":962480
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009358,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad9a981d08c7753ff7675bfc215d544e",
+    "wof:geomhash":"b4d633419929681bf4547e6d7b4f9a1f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421183117,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886752,
     "wof:name":"Srae Ambel",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/183/889/421183889.geojson
+++ b/data/421/183/889/421183889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062978,
-    "geom:area_square_m":762393054.735563,
+    "geom:area_square_m":762393296.16346,
     "geom:bbox":"105.664694,11.599002,106.028996,11.900538",
     "geom:latitude":11.760296,
     "geom:longitude":105.861713,
@@ -120,12 +120,13 @@
         "qs_pg:id":985879,
         "wd:id":"Q4929166"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009390,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f43cb85759258fc49cc64fbd942bd05",
+    "wof:geomhash":"dad7808ca9f301b41dc13648e11ac2be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421183889,
-    "wof:lastmodified":1690938133,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ponhea Kraek",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/183/891/421183891.geojson
+++ b/data/421/183/891/421183891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073882,
-    "geom:area_square_m":893681433.191408,
+    "geom:area_square_m":893680828.296684,
     "geom:bbox":"105.456135,11.796409,105.846149,12.139432",
     "geom:latitude":11.975616,
     "geom:longitude":105.65546,
@@ -166,12 +166,13 @@
         "wd:id":"Q15623578",
         "wk:page":"Tboung Khmum Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009391,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2919ac54d8033de8ddfc65328ec6327",
+    "wof:geomhash":"453a57c6cb3ed165e330125f6e67c1eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421183891,
-    "wof:lastmodified":1690938134,
+    "wof:lastmodified":1695886752,
     "wof:name":"Tboung Khmum",
     "wof:parent_id":1108804319,
     "wof:placetype":"county",

--- a/data/421/183/973/421183973.geojson
+++ b/data/421/183/973/421183973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091128,
-    "geom:area_square_m":1095335988.54753,
+    "geom:area_square_m":1095335988.547498,
     "geom:bbox":"103.006600377,13.3589947924,103.417987642,13.7508095951",
     "geom:latitude":13.574654,
     "geom:longitude":103.24411,
@@ -117,12 +117,13 @@
         "qs_pg:id":987094,
         "wd:id":"Q1385840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ab59aab772c03734db7957a44ea01b6",
+    "wof:geomhash":"f12bffb2a92a776c39318933079c4feb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421183973,
-    "wof:lastmodified":1582346020,
+    "wof:lastmodified":1695886787,
     "wof:name":"Preah Netr Preah",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/185/341/421185341.geojson
+++ b/data/421/185/341/421185341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016994,
-    "geom:area_square_m":204168602.983934,
+    "geom:area_square_m":204168640.196462,
     "geom:bbox":"106.940185,13.578954,107.092139,13.763942",
     "geom:latitude":13.682566,
     "geom:longitude":107.030404,
@@ -146,12 +146,13 @@
         "qs_pg:id":891117,
         "wd:id":"Q4856829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f93cb75c216ef33006b0cd780a3a4346",
+    "wof:geomhash":"470aad33adbd35578bdc0826c2dbcc8b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421185341,
-    "wof:lastmodified":1690938135,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ban Lung",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/185/505/421185505.geojson
+++ b/data/421/185/505/421185505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084818,
-    "geom:area_square_m":1020018267.484458,
+    "geom:area_square_m":1020018297.451527,
     "geom:bbox":"103.473705,13.232057,103.817409,13.633111",
     "geom:latitude":13.45049,
     "geom:longitude":103.647446,
@@ -113,12 +113,13 @@
         "qs_pg:id":897580,
         "wd:id":"Q1883685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009445,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73b0e38f4e625204dfce84d559576fa1",
+    "wof:geomhash":"5dd6f95ec7760854f2fb3b0db032aefb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421185505,
-    "wof:lastmodified":1690938134,
+    "wof:lastmodified":1695886787,
     "wof:name":"Puok",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/187/975/421187975.geojson
+++ b/data/421/187/975/421187975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212564,
-    "geom:area_square_m":2551286309.037,
+    "geom:area_square_m":2551286309.036993,
     "geom:bbox":"105.117924583,13.6344018508,105.899309653,14.160593",
     "geom:latitude":13.912669,
     "geom:longitude":105.461625,
@@ -115,12 +115,13 @@
         "wd:id":"Q4929159",
         "wk:page":"Chhaeb District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d677dec8377c3a284897fc643dafea23",
+    "wof:geomhash":"395ab1d9fdbc4176458b82067c63aaed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421187975,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886785,
     "wof:name":"Chhaeb",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/421/187/977/421187977.geojson
+++ b/data/421/187/977/421187977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00791,
-    "geom:area_square_m":96009544.465465,
+    "geom:area_square_m":96009598.238704,
     "geom:bbox":"104.744802,10.926754,104.863977,11.041562",
     "geom:latitude":10.994807,
     "geom:longitude":104.796735,
@@ -119,12 +119,13 @@
         "wd:id":"Q4929284",
         "wk:page":"Doun Kaev District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff0bd6a082f895ea905dc0bee24993ab",
+    "wof:geomhash":"fa15ac5df34a55589d4bc0568fc5c7d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421187977,
-    "wof:lastmodified":1690938128,
+    "wof:lastmodified":1695886785,
     "wof:name":"Doun Kaev",
     "wof:parent_id":85673107,
     "wof:placetype":"county",

--- a/data/421/188/047/421188047.geojson
+++ b/data/421/188/047/421188047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.246267,
-    "geom:area_square_m":2966234487.532645,
+    "geom:area_square_m":2966234487.533021,
     "geom:bbox":"105.068626557,12.7745830829,105.690618045,13.4490215648",
     "geom:latitude":13.070678,
     "geom:longitude":105.411375,
@@ -279,12 +279,13 @@
         "qs_pg:id":9926,
         "wd:id":"Q21072874"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b050dc360df7dd1aa86b9f556763ce8",
+    "wof:geomhash":"0cb07e236eebd23ac9730227a124883d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +295,7 @@
         }
     ],
     "wof:id":421188047,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886785,
     "wof:name":"Sandan",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/188/049/421188049.geojson
+++ b/data/421/188/049/421188049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00759,
-    "geom:area_square_m":91635392.651118,
+    "geom:area_square_m":91635544.364091,
     "geom:bbox":"105.982192,12.426706,106.093328,12.540123",
     "geom:latitude":12.489313,
     "geom:longitude":106.040673,
@@ -125,12 +125,13 @@
         "hasc:id":"KH.KH.KR",
         "qs_pg:id":9945
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61922b083c5eb57848ade04e986c7ae7",
+    "wof:geomhash":"cd025ebf2c868f1d4f6c51119433646e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421188049,
-    "wof:lastmodified":1636500705,
+    "wof:lastmodified":1695886765,
     "wof:name":"Kracheh",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/421/188/051/421188051.geojson
+++ b/data/421/188/051/421188051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.446748,
-    "geom:area_square_m":5382854295.149835,
+    "geom:area_square_m":5382853875.056566,
     "geom:bbox":"105.58847,12.634657,106.617447,13.406971",
     "geom:latitude":12.984577,
     "geom:longitude":106.089653,
@@ -89,12 +89,13 @@
         "hasc:id":"KH.KH.SB",
         "qs_pg:id":9950
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28445965c671bad8d04d9b2857f9bf77",
+    "wof:geomhash":"9180a90a928d4e26eaa5c3c2e939cd66",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421188051,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886751,
     "wof:name":"Sambour",
     "wof:parent_id":85673081,
     "wof:placetype":"county",

--- a/data/421/188/053/421188053.geojson
+++ b/data/421/188/053/421188053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189971,
-    "geom:area_square_m":2276267045.869472,
+    "geom:area_square_m":2276266915.748283,
     "geom:bbox":"106.988673,13.926782,107.559339,14.690179",
     "geom:latitude":14.296636,
     "geom:longitude":107.239641,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.RO.TV",
         "qs_pg:id":9978
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d57713170236a55d9521fe3f826a877",
+    "wof:geomhash":"9fe8a8c66c84d780502723d549627f08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421188053,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886752,
     "wof:name":"Ta Veaeng",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/188/055/421188055.geojson
+++ b/data/421/188/055/421188055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045288,
-    "geom:area_square_m":546704508.449981,
+    "geom:area_square_m":546704576.796395,
     "geom:bbox":"107.032872,12.370743,107.289532,12.647223",
     "geom:latitude":12.505466,
     "geom:longitude":107.16902,
@@ -143,12 +143,13 @@
         "qs_pg:id":9984,
         "wd:id":"Q4929483"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0e52b96645b87c744d3792aa15ba742",
+    "wof:geomhash":"466b8e39521c7bd1a909571fc535412c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421188055,
-    "wof:lastmodified":1690938129,
+    "wof:lastmodified":1695886786,
     "wof:name":"Saen Monourom",
     "wof:parent_id":85673085,
     "wof:placetype":"county",

--- a/data/421/188/235/421188235.geojson
+++ b/data/421/188/235/421188235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023928,
-    "geom:area_square_m":289652589.228615,
+    "geom:area_square_m":289652589.228471,
     "geom:bbox":"104.70310832,11.6640068729,104.888073199,11.8947284647",
     "geom:latitude":11.768469,
     "geom:longitude":104.800915,
@@ -108,12 +108,13 @@
         "qs_pg:id":1091006,
         "wd:id":"Q4930646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009538,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f81db48bd89122e05e741c89317260ab",
+    "wof:geomhash":"d22fdde4d8141c6e249d60899d6b67f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421188235,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Ponhea Lueu",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/188/239/421188239.geojson
+++ b/data/421/188/239/421188239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081876,
-    "geom:area_square_m":988674034.137433,
+    "geom:area_square_m":988674111.817504,
     "geom:bbox":"104.49788,12.207273,104.899245,12.607328",
     "geom:latitude":12.431188,
     "geom:longitude":104.707458,
@@ -107,12 +107,13 @@
         "qs_pg:id":1091008,
         "wd:id":"Q4929050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009538,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"def9aec998c633817be7376750ea363a",
+    "wof:geomhash":"a07b2c8e524f3159a91da439838adff2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421188239,
-    "wof:lastmodified":1690938130,
+    "wof:lastmodified":1695886786,
     "wof:name":"Kampong Leaeng",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/188/243/421188243.geojson
+++ b/data/421/188/243/421188243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096967,
-    "geom:area_square_m":1178211655.449519,
+    "geom:area_square_m":1178211457.421334,
     "geom:bbox":"103.562179,10.402056,103.968293,10.950396",
     "geom:latitude":10.686924,
     "geom:longitude":103.786027,
@@ -113,12 +113,13 @@
         "qs_pg:id":1091013,
         "wd:id":"Q4930264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009539,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0db6dfc80d20a081a546b5f065353e0",
+    "wof:geomhash":"f18cd991ec97a93df2a91bc70ce8d48c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421188243,
-    "wof:lastmodified":1690938129,
+    "wof:lastmodified":1695886785,
     "wof:name":"Prey Nob",
     "wof:parent_id":85673101,
     "wof:placetype":"county",

--- a/data/421/188/351/421188351.geojson
+++ b/data/421/188/351/421188351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029458,
-    "geom:area_square_m":356689735.043521,
+    "geom:area_square_m":356689735.043578,
     "geom:bbox":"104.932937983,11.5762201987,105.159342774,11.8521048816",
     "geom:latitude":11.694186,
     "geom:longitude":105.035902,
@@ -110,12 +110,13 @@
         "qs_pg:id":19967,
         "wd:id":"Q4930148"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009542,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6597524bfc32c008b3c54e2c06309e2d",
+    "wof:geomhash":"2426184d5ea69ca095787f30df48c0af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421188351,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Khsach Kandal",
     "wof:parent_id":85673051,
     "wof:placetype":"county",

--- a/data/421/191/397/421191397.geojson
+++ b/data/421/191/397/421191397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016156,
-    "geom:area_square_m":195863316.224479,
+    "geom:area_square_m":195863316.224516,
     "geom:bbox":"105.255607718,11.2170516748,105.391947829,11.4514877463",
     "geom:latitude":11.353857,
     "geom:longitude":105.316553,
@@ -116,12 +116,13 @@
         "qs_pg:id":19971,
         "wd:id":"Q7157916"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bcc7e755229128579f6ee6a179352c2",
+    "wof:geomhash":"9f50076ebffd3d9f9b19346817f8d1ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421191397,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Peam Ro",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/421/194/641/421194641.geojson
+++ b/data/421/194/641/421194641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155142,
-    "geom:area_square_m":1860957918.803366,
+    "geom:area_square_m":1860957918.804355,
     "geom:bbox":"106.612687655,13.77,107.067391618,14.3862048503",
     "geom:latitude":14.051057,
     "geom:longitude":106.855276,
@@ -113,12 +113,13 @@
         "qs_pg:id":891118,
         "wd:id":"Q4930123"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009814,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2145c59641ff643e86d609987a26583a",
+    "wof:geomhash":"4a545eeb43ba1284fe873a6924d9f4fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421194641,
-    "wof:lastmodified":1582346017,
+    "wof:lastmodified":1695886785,
     "wof:name":"Veun Sai",
     "wof:parent_id":85673089,
     "wof:placetype":"county",

--- a/data/421/194/643/421194643.geojson
+++ b/data/421/194/643/421194643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047524,
-    "geom:area_square_m":571219416.903117,
+    "geom:area_square_m":571219177.479435,
     "geom:bbox":"103.392259,13.346385,103.615768,13.75026",
     "geom:latitude":13.576659,
     "geom:longitude":103.485082,
@@ -116,12 +116,13 @@
         "qs_pg:id":891119,
         "wd:id":"Q1883697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009815,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"983b2421c53d36e5cbafeaed0dba1e9a",
+    "wof:geomhash":"9e57db1cdf83f7aedd09ef5c58ec1d4d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421194643,
-    "wof:lastmodified":1690938125,
+    "wof:lastmodified":1695886785,
     "wof:name":"Kralanh",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/194/855/421194855.geojson
+++ b/data/421/194/855/421194855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006904,
-    "geom:area_square_m":83662208.147749,
+    "geom:area_square_m":83662226.850809,
     "geom:bbox":"104.452943,11.429542,104.57009,11.517236",
     "geom:latitude":11.471541,
     "geom:longitude":104.507079,
@@ -115,12 +115,13 @@
         "qs_pg:id":19968,
         "wd:id":"Q5088735"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009822,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89d1550b1eb1fe24e65e15b96bc052e5",
+    "wof:geomhash":"9bab54329fd252c7de95247995a9e58d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421194855,
-    "wof:lastmodified":1690938126,
+    "wof:lastmodified":1695886785,
     "wof:name":"Chbar Mon",
     "wof:parent_id":85673053,
     "wof:placetype":"county",

--- a/data/421/194/857/421194857.geojson
+++ b/data/421/194/857/421194857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314695,
-    "geom:area_square_m":3809664622.285503,
+    "geom:area_square_m":3809664622.285884,
     "geom:bbox":"103.101355364,11.264698998,103.854622594,12.1161115412",
     "geom:latitude":11.752898,
     "geom:longitude":103.493504,
@@ -110,12 +110,13 @@
         "qs_pg:id":19969,
         "wd:id":"Q4930009"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009822,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94759c009454790d4f88acf673668499",
+    "wof:geomhash":"ba5a56dd0cd2a05e2a313985d96f2721",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421194857,
-    "wof:lastmodified":1582346017,
+    "wof:lastmodified":1695886785,
     "wof:name":"Thma Bang",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/194/859/421194859.geojson
+++ b/data/421/194/859/421194859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183405,
-    "geom:area_square_m":2202483470.278395,
+    "geom:area_square_m":2202483179.091137,
     "geom:bbox":"104.358251,13.504392,104.918924,14.08624",
     "geom:latitude":13.787928,
     "geom:longitude":104.610038,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.PH.KL",
         "qs_pg:id":19970
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009822,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c80acf775bf6817e2d974c2d52eee8f",
+    "wof:geomhash":"427a618bc145b9979f74598dc40c4c57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421194859,
-    "wof:lastmodified":1627522283,
+    "wof:lastmodified":1695886750,
     "wof:name":"Kuleaen",
     "wof:parent_id":85673071,
     "wof:placetype":"county",

--- a/data/421/195/831/421195831.geojson
+++ b/data/421/195/831/421195831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030568,
-    "geom:area_square_m":369588637.85828,
+    "geom:area_square_m":369588637.858284,
     "geom:bbox":"104.975379731,11.958736093,105.156146608,12.2267298329",
     "geom:latitude":12.094282,
     "geom:longitude":105.062946,
@@ -118,12 +118,13 @@
         "wd:id":"Q4930086",
         "wk:page":"Cheung Prey District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009860,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f4e0a7907f0ad23f431bb9dfd21e986",
+    "wof:geomhash":"6cdfea8764376c9c77b9785a50a3d3d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421195831,
-    "wof:lastmodified":1582346017,
+    "wof:lastmodified":1695886785,
     "wof:name":"Cheung Prey",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/421/196/403/421196403.geojson
+++ b/data/421/196/403/421196403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1183,
-    "geom:area_square_m":1427584155.373651,
+    "geom:area_square_m":1427583523.506306,
     "geom:bbox":"102.52288,12.372945,103.091837,12.759121",
     "geom:latitude":12.59745,
     "geom:longitude":102.85582,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.BA.ST",
         "qs_pg:id":149814
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009880,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1d4d0ee2fe4342c5659a1dbeceec12d",
+    "wof:geomhash":"371365c88b9296c8b9f8fd0fd71b555c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421196403,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886751,
     "wof:name":"Samlout",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/198/129/421198129.geojson
+++ b/data/421/198/129/421198129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045863,
-    "geom:area_square_m":551105905.801502,
+    "geom:area_square_m":551105905.801426,
     "geom:bbox":"102.653685694,13.4829876718,102.929794406,13.8263754297",
     "geom:latitude":13.643907,
     "geom:longitude":102.808217,
@@ -116,12 +116,13 @@
         "qs_pg:id":987093,
         "wd:id":"Q4929257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009938,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53a0f6de6bbece9ac959235280350afa",
+    "wof:geomhash":"a2af6870f2ea354f1fc2110f1e677082",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421198129,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Ou Chrov",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/198/921/421198921.geojson
+++ b/data/421/198/921/421198921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109175,
-    "geom:area_square_m":1318531319.611841,
+    "geom:area_square_m":1318530987.538902,
     "geom:bbox":"104.852326,12.190697,105.401076,12.540843",
     "geom:latitude":12.388262,
     "geom:longitude":105.10465,
@@ -118,12 +118,13 @@
         "wd:id":"Q4858526",
         "wk:page":"Baray District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009966,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3fd3f358f1cc626ecdd2ae7851b5e007",
+    "wof:geomhash":"ab6a0d0f6f1eba609213c371047d1ee9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421198921,
-    "wof:lastmodified":1690938131,
+    "wof:lastmodified":1695886786,
     "wof:name":"Baray",
     "wof:parent_id":85673057,
     "wof:placetype":"county",

--- a/data/421/198/923/421198923.geojson
+++ b/data/421/198/923/421198923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058778,
-    "geom:area_square_m":710340074.248581,
+    "geom:area_square_m":710340074.248788,
     "geom:bbox":"104.388843968,12.0502874682,104.800374125,12.3685246551",
     "geom:latitude":12.215608,
     "geom:longitude":104.60263,
@@ -109,12 +109,13 @@
         "wd:id":"Q4929609",
         "wk:page":"Rolea B'ier District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459009966,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"121dceb8a59d139b768fa447cc072317",
+    "wof:geomhash":"4ec8d117e682d6b98a42319965676669",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421198923,
-    "wof:lastmodified":1582346019,
+    "wof:lastmodified":1695886786,
     "wof:name":"Rolea B'ier",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/200/831/421200831.geojson
+++ b/data/421/200/831/421200831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160507,
-    "geom:area_square_m":1928320431.859926,
+    "geom:area_square_m":1928319578.133497,
     "geom:bbox":"104.075501,13.397268,104.455052,13.964239",
     "geom:latitude":13.688379,
     "geom:longitude":104.260692,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.SI.SL",
         "qs_pg:id":897582
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010043,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fd88d4c72cbd78cfca001d2619a93ae",
+    "wof:geomhash":"1ce315c38e7681fcf293ba87d69b8f84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421200831,
-    "wof:lastmodified":1627522286,
+    "wof:lastmodified":1695886752,
     "wof:name":"Svay Leu",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/200/833/421200833.geojson
+++ b/data/421/200/833/421200833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09146,
-    "geom:area_square_m":1098064422.388892,
+    "geom:area_square_m":1098064446.330398,
     "geom:bbox":"103.684561,13.681091,104.115724,13.969398",
     "geom:latitude":13.845861,
     "geom:longitude":103.916689,
@@ -120,12 +120,13 @@
         "qs_pg:id":897583,
         "wd:id":"Q4930239"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010043,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2db5ff1d409644d15455d6545649e10f",
+    "wof:geomhash":"bc6e4694d85ee992670af95a754102de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421200833,
-    "wof:lastmodified":1690938132,
+    "wof:lastmodified":1695886786,
     "wof:name":"Varin",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/200/835/421200835.geojson
+++ b/data/421/200/835/421200835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058753,
-    "geom:area_square_m":705878652.260893,
+    "geom:area_square_m":705878762.819458,
     "geom:bbox":"105.926287,13.388174,106.206134,13.924656",
     "geom:latitude":13.68211,
     "geom:longitude":106.067869,
@@ -106,12 +106,13 @@
         "qs_pg:id":897584,
         "wd:id":"Q4929505"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010043,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01efb588effcff8401a402b97ec2dc1d",
+    "wof:geomhash":"eeeea7c166141e8cd846fa25fcea42f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421200835,
-    "wof:lastmodified":1690938132,
+    "wof:lastmodified":1695886786,
     "wof:name":"Stueng Traeng",
     "wof:parent_id":85673075,
     "wof:placetype":"county",

--- a/data/421/201/861/421201861.geojson
+++ b/data/421/201/861/421201861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120774,
-    "geom:area_square_m":1461794236.030361,
+    "geom:area_square_m":1461794477.255139,
     "geom:bbox":"102.776033,11.484782,103.200629,12.021579",
     "geom:latitude":11.807252,
     "geom:longitude":103.009954,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.KK.MS",
         "qs_pg:id":214991
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010090,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a2013aefddfc40ce38e86c73c927716",
+    "wof:geomhash":"9b11df213c7c847589ffed909979769f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421201861,
-    "wof:lastmodified":1627522284,
+    "wof:lastmodified":1695886751,
     "wof:name":"Mondol Seima",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/202/233/421202233.geojson
+++ b/data/421/202/233/421202233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001994,
-    "geom:area_square_m":24120142.078395,
+    "geom:area_square_m":24120269.531061,
     "geom:bbox":"105.399682,11.961295,105.474441,12.015001",
     "geom:latitude":11.984705,
     "geom:longitude":105.442424,
@@ -122,12 +122,13 @@
         "wd:id":"Q4930039",
         "wk:page":"Kampong Siem District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010110,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e08510f2a87cbefd132867b19fda23f",
+    "wof:geomhash":"106081d6979b2d6a5b3998b0e1c052c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421202233,
-    "wof:lastmodified":1690938127,
+    "wof:lastmodified":1695886765,
     "wof:name":"Kampong Cham",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/421/202/235/421202235.geojson
+++ b/data/421/202/235/421202235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04209,
-    "geom:area_square_m":508266573.684003,
+    "geom:area_square_m":508266573.68383,
     "geom:bbox":"104.33947966,12.2894088455,104.625040279,12.6089241343",
     "geom:latitude":12.422453,
     "geom:longitude":104.461909,
@@ -115,12 +115,13 @@
         "wd:id":"Q4860702",
         "wk:page":"Baribour District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010110,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0709d02ca947574f91080481098ff0c",
+    "wof:geomhash":"3d982ca7d5f93b0afbbaeb944c38adf3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421202235,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886785,
     "wof:name":"Baribour",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/202/239/421202239.geojson
+++ b/data/421/202/239/421202239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097818,
-    "geom:area_square_m":1178265238.798539,
+    "geom:area_square_m":1178265114.224009,
     "geom:bbox":"103.163544,12.89,103.742986,13.242126",
     "geom:latitude":13.057167,
     "geom:longitude":103.410873,
@@ -88,12 +88,13 @@
         "hasc:id":"KH.BA.SK",
         "qs_pg:id":10018
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010110,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4520bbae2bd8db6ed3a21f0838b94e68",
+    "wof:geomhash":"24e5ddefddc010a1df633e2e53f177f9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421202239,
-    "wof:lastmodified":1627522285,
+    "wof:lastmodified":1695886751,
     "wof:name":"Sangkae",
     "wof:parent_id":85673015,
     "wof:placetype":"county",

--- a/data/421/202/305/421202305.geojson
+++ b/data/421/202/305/421202305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041617,
-    "geom:area_square_m":504981008.191559,
+    "geom:area_square_m":504981003.68692,
     "geom:bbox":"105.429613,10.947911,105.63458,11.261516",
     "geom:latitude":11.095465,
     "geom:longitude":105.535191,
@@ -111,12 +111,13 @@
         "qs_pg:id":220666,
         "wd:id":"Q4929343"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53de7a731c9414a7047f64cd9764b6c2",
+    "wof:geomhash":"b7f02caeb772c4028cf537617ab8b36f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421202305,
-    "wof:lastmodified":1690938128,
+    "wof:lastmodified":1695886785,
     "wof:name":"Kampong Trabaek",
     "wof:parent_id":85673067,
     "wof:placetype":"county",

--- a/data/421/202/413/421202413.geojson
+++ b/data/421/202/413/421202413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0903,
-    "geom:area_square_m":1095710591.409937,
+    "geom:area_square_m":1095710246.462004,
     "geom:bbox":"103.155202,10.863722,103.603482,11.315516",
     "geom:latitude":11.093063,
     "geom:longitude":103.380204,
@@ -115,12 +115,13 @@
         "wd:id":"Q4929301",
         "wk:page":"Botum Sakor District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010117,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c0b6fe560a87f6d8db7021178a0568b",
+    "wof:geomhash":"1bff8b30dbbd9e15335833ca1b2096cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421202413,
-    "wof:lastmodified":1690938127,
+    "wof:lastmodified":1695886785,
     "wof:name":"Botum Sakor",
     "wof:parent_id":85673019,
     "wof:placetype":"county",

--- a/data/421/202/559/421202559.geojson
+++ b/data/421/202/559/421202559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003998,
-    "geom:area_square_m":48305394.232924,
+    "geom:area_square_m":48305448.825782,
     "geom:bbox":"104.646082,12.217285,104.716871,12.321925",
     "geom:latitude":12.260312,
     "geom:longitude":104.678423,
@@ -117,12 +117,13 @@
         "wd:id":"Q2508561",
         "wk:page":"Kampong Cham District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010122,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48c8bc7adbbc52d9888db408bf46ae24",
+    "wof:geomhash":"5c80b759e2f6a5daafdb16723c6b229d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421202559,
-    "wof:lastmodified":1690938127,
+    "wof:lastmodified":1695886785,
     "wof:name":"Kampong Chhnang",
     "wof:parent_id":85673047,
     "wof:placetype":"county",

--- a/data/421/203/239/421203239.geojson
+++ b/data/421/203/239/421203239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132517,
-    "geom:area_square_m":1599950625.657952,
+    "geom:area_square_m":1599950625.658169,
     "geom:bbox":"103.991753432,12.1991617077,104.391268847,12.7276785005",
     "geom:latitude":12.467397,
     "geom:longitude":104.186757,
@@ -112,12 +112,13 @@
         "wd:id":"Q4929565",
         "wk:page":"Krakor District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfdc66c447bf28a8eedb43d9007fe396",
+    "wof:geomhash":"5462f1ce6e0b093e79cf0e888001708b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421203239,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886785,
     "wof:name":"Krakor",
     "wof:parent_id":85673023,
     "wof:placetype":"county",

--- a/data/421/203/293/421203293.geojson
+++ b/data/421/203/293/421203293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091684,
-    "geom:area_square_m":1099953613.034439,
+    "geom:area_square_m":1099953613.034917,
     "geom:bbox":"102.794382528,13.8176161317,103.220454305,14.2403627882",
     "geom:latitude":14.013694,
     "geom:longitude":103.039988,
@@ -119,12 +119,13 @@
         "qs_pg:id":231047,
         "wd:id":"Q1385830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010146,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b70a17a53d3c82bb2bc1c28383258e83",
+    "wof:geomhash":"09625ba0aed894b2c17a14f73515e511",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421203293,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886785,
     "wof:name":"Thma Puok",
     "wof:parent_id":85673011,
     "wof:placetype":"county",

--- a/data/421/204/115/421204115.geojson
+++ b/data/421/204/115/421204115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054417,
-    "geom:area_square_m":654815400.255362,
+    "geom:area_square_m":654815400.255111,
     "geom:bbox":"103.7255697,13.0942176726,103.991431346,13.4704467236",
     "geom:latitude":13.304637,
     "geom:longitude":103.842816,
@@ -233,12 +233,13 @@
         "hasc:id":"KH.SI.SR",
         "qs_pg:id":238186
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010174,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97fa63e9e5bd693c931b05b21b3a1b55",
+    "wof:geomhash":"28293b96122b1a8fb928f2c773c15675",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -248,7 +249,7 @@
         }
     ],
     "wof:id":421204115,
-    "wof:lastmodified":1582346018,
+    "wof:lastmodified":1695886786,
     "wof:name":"Siem Reap",
     "wof:parent_id":85673029,
     "wof:placetype":"county",

--- a/data/421/205/043/421205043.geojson
+++ b/data/421/205/043/421205043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035763,
-    "geom:area_square_m":432458103.618561,
+    "geom:area_square_m":432457960.180054,
     "geom:bbox":"105.326616,11.921554,105.548358,12.187687",
     "geom:latitude":12.059684,
     "geom:longitude":105.434794,
@@ -119,12 +119,13 @@
         "qs_pg:id":1191491,
         "wd:id":"Q4930039"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1459010210,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"636ac24c66f94d8d7971acaa88cec64c",
+    "wof:geomhash":"77d5b508de5c72b6ebdeb9d9187cad4f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421205043,
-    "wof:lastmodified":1690938128,
+    "wof:lastmodified":1695886786,
     "wof:name":"Kampong Siem",
     "wof:parent_id":85673041,
     "wof:placetype":"county",

--- a/data/856/323/59/85632359.geojson
+++ b/data/856/323/59/85632359.geojson
@@ -1269,6 +1269,7 @@
         "hasc:id":"KH",
         "icao:code":"XU",
         "ioc:id":"CAM",
+        "iso:code":"KH",
         "itu:id":"CBG",
         "m49:code":"116",
         "marc:id":"cb",
@@ -1282,6 +1283,7 @@
         "wk:page":"Cambodia",
         "wmo:id":"KP"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:country_alpha3":"KHM",
     "wof:geom_alt":[
@@ -1303,7 +1305,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1694639531,
+    "wof:lastmodified":1695881188,
     "wof:name":"Cambodia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/730/11/85673011.geojson
+++ b/data/856/730/11/85673011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.515004,
-    "geom:area_square_m":6186739091.010147,
+    "geom:area_square_m":6186739164.967072,
     "geom:bbox":"102.333542,13.358995,103.441361,14.240363",
     "geom:latitude":13.70663,
     "geom:longitude":103.013159,
@@ -319,16 +319,18 @@
         "gn:id":1899273,
         "gp:id":20070093,
         "hasc:id":"KH.OM",
+        "iso:code":"KH-1",
         "iso:id":"KH-1",
         "qs_pg:id":888184,
         "wd:id":"Q3817",
         "wk:page":"Banteay Meanchey Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a90ad8984bec399cf95b9f57bae8bbfe",
+    "wof:geomhash":"fbe20414c918b541758a6381d3850323",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938099,
+    "wof:lastmodified":1695884484,
     "wof:name":"B\u00e2nt\u00e9ay M\u00e9anchey",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/15/85673015.geojson
+++ b/data/856/730/15/85673015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.013176,
-    "geom:area_square_m":12207811523.895376,
+    "geom:area_square_m":12207811407.084326,
     "geom:bbox":"102.345097,12.372945,103.918881,13.479488",
     "geom:latitude":12.981186,
     "geom:longitude":103.102112,
@@ -302,16 +302,18 @@
         "gn:id":1821310,
         "gp:id":20070098,
         "hasc:id":"KH.BA",
+        "iso:code":"KH-2",
         "iso:id":"KH-2",
         "qs_pg:id":896382,
         "wd:id":"Q810923",
         "wk:page":"Battambang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e16ffb1a134ae648d00ee2df0e3eb90",
+    "wof:geomhash":"7e02b18b293598dac966ca9e0ff1b7c0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938102,
+    "wof:lastmodified":1695884484,
     "wof:name":"Batd\u00e2mb\u00e2ng",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/19/85673019.geojson
+++ b/data/856/730/19/85673019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.988378,
-    "geom:area_square_m":11976666240.413164,
+    "geom:area_square_m":11976665770.658022,
     "geom:bbox":"102.776033,10.855361,104.077972,12.116112",
     "geom:latitude":11.483611,
     "geom:longitude":103.459315,
@@ -298,17 +298,19 @@
         "gn:id":1831037,
         "gp:id":2344934,
         "hasc:id":"KH.KK",
+        "iso:code":"KH-9",
         "iso:id":"KH-9",
         "qs_pg:id":1083806,
         "unlc:id":"KH-9",
         "wd:id":"Q466000",
         "wk:page":"Koh Kong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78032ef322e7118c84adc80ba462eff2",
+    "wof:geomhash":"3c4a0d2fbe98067dd06a2b8accec0502",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938100,
+    "wof:lastmodified":1695884485,
     "wof:name":"Ka\u00f4h Kong",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/23/85673023.geojson
+++ b/data/856/730/23/85673023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.035021,
-    "geom:area_square_m":12501120951.486954,
+    "geom:area_square_m":12501120421.927929,
     "geom:bbox":"102.70351,11.839763,104.391269,13.053045",
     "geom:latitude":12.367472,
     "geom:longitude":103.635652,
@@ -303,16 +303,18 @@
         "gn:id":1821301,
         "gp:id":2344937,
         "hasc:id":"KH.PO",
+        "iso:code":"KH-15",
         "iso:id":"KH-15",
         "qs_pg:id":423610,
         "wd:id":"Q834464",
         "wk:page":"Pursat Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c49503b260ac535f96b6c6dc49bd21a4",
+    "wof:geomhash":"5e363f1d91946e7c88b9a8845b15f351",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938102,
+    "wof:lastmodified":1695884875,
     "wof:name":"Pouthisat",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/29/85673029.geojson
+++ b/data/856/730/29/85673029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.951485,
-    "geom:area_square_m":11441378572.589142,
+    "geom:area_square_m":11441378953.289249,
     "geom:bbox":"103.392259,12.748222,104.680289,13.96943",
     "geom:latitude":13.47306,
     "geom:longitude":104.018906,
@@ -286,16 +286,18 @@
         "gn:id":1822213,
         "gp:id":2344941,
         "hasc:id":"KH.SI",
+        "iso:code":"KH-17",
         "iso:id":"KH-17",
         "qs_pg:id":672297,
         "unlc:id":"KH-17",
         "wd:id":"Q652818"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"985a0f935aef4ed3a41d34641dcd10d8",
+    "wof:geomhash":"d6134b66d82fcd6d5df1337f5f724041",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938099,
+    "wof:lastmodified":1695884485,
     "wof:name":"Siemr\u00e9ab",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/33/85673033.geojson
+++ b/data/856/730/33/85673033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.555353,
-    "geom:area_square_m":6658238402.194561,
+    "geom:area_square_m":6658238975.405189,
     "geom:bbox":"103.034804,13.880749,104.5069,14.440413",
     "geom:latitude":14.165259,
     "geom:longitude":103.788594,
@@ -315,16 +315,18 @@
         "gn:id":1822210,
         "gp:id":20070092,
         "hasc:id":"KH.OC",
+        "iso:code":"KH-22",
         "iso:id":"KH-22",
         "qs_pg:id":332098,
         "unlc:id":"KH-22",
         "wd:id":"Q629538"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3ed0a7ec6ba283b593918513a1e08e44",
+    "wof:geomhash":"41858df10daddedd0add7765837f5122",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938099,
+    "wof:lastmodified":1695884875,
     "wof:name":"Otdar Mean Chey",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/37/85673037.geojson
+++ b/data/856/730/37/85673037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09051,
-    "geom:area_square_m":1091022043.704001,
+    "geom:area_square_m":1091022226.08987,
     "geom:bbox":"102.485557,12.661085,102.755952,13.115057",
     "geom:latitude":12.878767,
     "geom:longitude":102.632741,
@@ -293,17 +293,19 @@
         "gn:id":1830206,
         "gp:id":20070097,
         "hasc:id":"KH.PL",
+        "iso:code":"KH-24",
         "iso:id":"KH-24",
         "qs_pg:id":1181214,
         "unlc:id":"KH-24",
         "wd:id":"Q506646",
         "wk:page":"Pailin Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cdd13eb66df8d679cff847d6919ffd6f",
+    "wof:geomhash":"2f7c42a2eee3d6070b96e732341d93df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938101,
+    "wof:lastmodified":1695884875,
     "wof:name":"Krong Pailin",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/41/85673041.geojson
+++ b/data/856/730/41/85673041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.378402,
-    "geom:area_square_m":4574596681.60238,
+    "geom:area_square_m":4574597378.002566,
     "geom:bbox":"104.818481,11.732076,105.777688,12.501578",
     "geom:latitude":12.125373,
     "geom:longitude":105.273755,
@@ -315,16 +315,18 @@
         "gn:id":1831172,
         "gp:id":2344928,
         "hasc:id":"KH.KC",
+        "iso:code":"KH-3",
         "iso:id":"KH-3",
         "qs_pg:id":1285060,
         "wd:id":"Q142258",
         "wk:page":"Kampong Cham Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c9ed66fcaf8b311923a57b4f9752ab6",
+    "wof:geomhash":"2fae47caaa96062170d12a4a542e1d04",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938102,
+    "wof:lastmodified":1695884485,
     "wof:name":"K\u00e2mp\u00f3ng Cham",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/47/85673047.geojson
+++ b/data/856/730/47/85673047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.449011,
-    "geom:area_square_m":5427369145.700543,
+    "geom:area_square_m":5427369474.127123,
     "geom:bbox":"104.171365,11.733954,104.903516,12.608924",
     "geom:latitude":12.166258,
     "geom:longitude":104.559437,
@@ -309,17 +309,19 @@
         "gn:id":1831166,
         "gp:id":2344929,
         "hasc:id":"KH.KG",
+        "iso:code":"KH-4",
         "iso:id":"KH-4",
         "qs_pg:id":1285061,
         "unlc:id":"KH-4",
         "wd:id":"Q877468",
         "wk:page":"Kampong Chhnang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d31f3ff73df4fb94f9e2ddfae1b46d5",
+    "wof:geomhash":"43d408a4b3f9dbb4bcbf395adfd09530",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938103,
+    "wof:lastmodified":1695884485,
     "wof:name":"K\u00e2mp\u00f3ng Chhnang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/51/85673051.geojson
+++ b/data/856/730/51/85673051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26893,
-    "geom:area_square_m":3259477447.253802,
+    "geom:area_square_m":3259477397.853993,
     "geom:bbox":"104.655884,10.897906,105.302079,11.894728",
     "geom:latitude":11.422155,
     "geom:longitude":105.019126,
@@ -307,16 +307,18 @@
         "gn:id":1831095,
         "gp:id":2344933,
         "hasc:id":"KH.KN",
+        "iso:code":"KH-8",
         "iso:id":"KH-8",
         "qs_pg:id":1285062,
         "wd:id":"Q466031",
         "wk:page":"Kandal Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fdc3a4f3eaa9d405268e0aef4e04a0e8",
+    "wof:geomhash":"d4636d229a33bf1f6bbb6f85d6df92e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938098,
+    "wof:lastmodified":1695884484,
     "wof:name":"K\u00e2ndal",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/53/85673053.geojson
+++ b/data/856/730/53/85673053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.577718,
-    "geom:area_square_m":6999251060.382603,
+    "geom:area_square_m":6999250535.626396,
     "geom:bbox":"103.772811,11.077085,104.789342,12.075546",
     "geom:latitude":11.535323,
     "geom:longitude":104.293564,
@@ -290,15 +290,17 @@
         "gn:id":1831132,
         "gp:id":2344930,
         "hasc:id":"KH.KS",
+        "iso:code":"KH-5",
         "iso:id":"KH-5",
         "qs_pg:id":1134962,
         "wd:id":"Q652867"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b6dee32a2954b837337fd0a55b8fa69",
+    "wof:geomhash":"d0dd36ec8ec63508fbe5bc18cc069f85",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938101,
+    "wof:lastmodified":1695884485,
     "wof:name":"K\u00e2mp\u00f3ng Sp\u0153",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/57/85673057.geojson
+++ b/data/856/730/57/85673057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.071917,
-    "geom:area_square_m":12923791655.725243,
+    "geom:area_square_m":12923790894.736954,
     "geom:bbox":"104.171101,12.190697,105.735496,13.449022",
     "geom:latitude":12.822568,
     "geom:longitude":105.045736,
@@ -315,17 +315,19 @@
         "gn:id":1831124,
         "gp:id":2344931,
         "hasc:id":"KH.KT",
+        "iso:code":"KH-6",
         "iso:id":"KH-6",
         "qs_pg:id":318347,
         "unlc:id":"KH-6",
         "wd:id":"Q502148",
         "wk:page":"Kampong Thom Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95267e981cbf5b7530d6b8f2b4848f94",
+    "wof:geomhash":"3119fe414e5b4dc43afb1c94bdda3b00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -340,7 +342,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938097,
+    "wof:lastmodified":1695884484,
     "wof:name":"K\u00e2mp\u00f3ng Thum",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/63/85673063.geojson
+++ b/data/856/730/63/85673063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057069,
-    "geom:area_square_m":691352194.17042,
+    "geom:area_square_m":691352194.170246,
     "geom:bbox":"104.720740775,11.4236649278,105.04963697,11.7367342189",
     "geom:latitude":11.563186,
     "geom:longitude":104.865757,
@@ -510,9 +510,11 @@
         "gn:id":1830103,
         "gp:id":20070095,
         "hasc:id":"KH.PP",
+        "iso:code":"KH-12",
         "iso:id":"KH-12",
         "qs_pg:id":241614
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1125853197
     ],
@@ -520,7 +522,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d90893307c4a5e82d36f1c07f66ab35",
+    "wof:geomhash":"69824c4a4483606c5cf60a2e50579194",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -535,7 +537,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1582346005,
+    "wof:lastmodified":1695884363,
     "wof:name":"Phnom Penh",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/67/85673067.geojson
+++ b/data/856/730/67/85673067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394362,
-    "geom:area_square_m":4780173808.010448,
+    "geom:area_square_m":4780173282.7752,
     "geom:bbox":"105.103667,10.859526,105.802379,11.868529",
     "geom:latitude":11.396387,
     "geom:longitude":105.42527,
@@ -294,16 +294,18 @@
         "gn:id":1822609,
         "gp:id":2344939,
         "hasc:id":"KH.PY",
+        "iso:code":"KH-14",
         "iso:id":"KH-14",
         "qs_pg:id":1285063,
         "wd:id":"Q856788",
         "wk:page":"Prey Veng Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78b3903d6fc1d3dd99fbfcce3657174e",
+    "wof:geomhash":"23ce945f9870b6f23b70b52988eea0b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938098,
+    "wof:lastmodified":1695884484,
     "wof:name":"Prey V\u00eang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/71/85673071.geojson
+++ b/data/856/730/71/85673071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.173971,
-    "geom:area_square_m":14097225936.817955,
+    "geom:area_square_m":14097225936.820705,
     "geom:bbox":"104.358251,13.054435,105.89931,14.437626",
     "geom:latitude":13.79878,
     "geom:longitude":105.007166,
@@ -306,17 +306,19 @@
         "gn:id":1822676,
         "gp:id":2344938,
         "hasc:id":"KH.PH",
+        "iso:code":"KH-13",
         "iso:id":"KH-13",
         "qs_pg:id":1083808,
         "unlc:id":"KH-13",
         "wd:id":"Q502151",
         "wk:page":"Preah Vihear Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9213f0dee0c9a11821d48e0121ec89b",
+    "wof:geomhash":"b2bb43cfbd1a07cb7964664803f5e887",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938103,
+    "wof:lastmodified":1695884485,
     "wof:name":"Preah Vih\u00e9ar",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/75/85673075.geojson
+++ b/data/856/730/75/85673075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.00587,
-    "geom:area_square_m":12078256997.225163,
+    "geom:area_square_m":12078256568.937935,
     "geom:bbox":"105.519569,13.112982,106.79,14.593423",
     "geom:latitude":13.805348,
     "geom:longitude":106.176282,
@@ -294,15 +294,17 @@
         "gn:id":1822028,
         "gp:id":2344942,
         "hasc:id":"KH.ST",
+        "iso:code":"KH-19",
         "iso:id":"KH-19",
         "qs_pg:id":1134965,
         "wd:id":"Q837889"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a206c30dc04f526be59a5aab52ab72e6",
+    "wof:geomhash":"3f574eea6fa2b4be73be758d5f114f50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938100,
+    "wof:lastmodified":1695884363,
     "wof:name":"St\u0153ng Tr\u00eang",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/81/85673081.geojson
+++ b/data/856/730/81/85673081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.996307,
-    "geom:area_square_m":12021241603.69725,
+    "geom:area_square_m":12021241307.561924,
     "geom:bbox":"105.58847,11.949355,106.801823,13.406971",
     "geom:latitude":12.628467,
     "geom:longitude":106.169959,
@@ -298,16 +298,18 @@
         "gn:id":1830563,
         "gp:id":2344935,
         "hasc:id":"KH.KH",
+        "iso:code":"KH-10",
         "iso:id":"KH-10",
         "qs_pg:id":1134963,
         "unlc:id":"KH-10",
         "wd:id":"Q785896"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ee3592a0127bf425676d943edce6d30",
+    "wof:geomhash":"cc86442393898b237924fddaebd39aa5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938101,
+    "wof:lastmodified":1695884485,
     "wof:name":"Kr\u00e2ch\u00e9h",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/85/85673085.geojson
+++ b/data/856/730/85/85673085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.134911,
-    "geom:area_square_m":13686261353.28319,
+    "geom:area_square_m":13686261966.131145,
     "geom:bbox":"106.338916,12.06183,107.602729,13.418234",
     "geom:latitude":12.766516,
     "geom:longitude":106.991572,
@@ -300,17 +300,19 @@
         "gn:id":1830306,
         "gp:id":2344936,
         "hasc:id":"KH.MK",
+        "iso:code":"KH-11",
         "iso:id":"KH-11",
         "qs_pg:id":1083807,
         "unlc:id":"KH-11",
         "wd:id":"Q652830",
         "wk:page":"Mondulkiri Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2da3bc7904d1b9ef6e3bd27e10f12805",
+    "wof:geomhash":"95c41d8340d829f023f3f399ad6d4821",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938103,
+    "wof:lastmodified":1695884485,
     "wof:name":"M\u00f4nd\u00f3l Kiri",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/89/85673089.geojson
+++ b/data/856/730/89/85673089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.985043,
-    "geom:area_square_m":11828601062.552122,
+    "geom:area_square_m":11828601559.072926,
     "geom:bbox":"106.52909,13.171389,107.627687,14.690179",
     "geom:latitude":13.796811,
     "geom:longitude":107.087174,
@@ -305,15 +305,17 @@
         "gn:id":1822449,
         "gp:id":2344940,
         "hasc:id":"KH.RO",
+        "iso:code":"KH-16",
         "iso:id":"KH-16",
         "qs_pg:id":1134964,
         "wd:id":"Q747846"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dcaa5345ed4d8bf7d3280804ea979f13",
+    "wof:geomhash":"b7a2e5983c0d84326d23323cf3deca74",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938100,
+    "wof:lastmodified":1695884485,
     "wof:name":"R\u00f4t\u00e2n\u00f4kiri",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/93/85673093.geojson
+++ b/data/856/730/93/85673093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389937,
-    "geom:area_square_m":4736302017.150033,
+    "geom:area_square_m":4736301839.328018,
     "geom:bbox":"103.916671,10.404543,104.727201,11.172214",
     "geom:latitude":10.795169,
     "geom:longitude":104.310225,
@@ -303,17 +303,19 @@
         "gn:id":1831111,
         "gp:id":2344932,
         "hasc:id":"KH.KP",
+        "iso:code":"KH-7",
         "iso:id":"KH-7",
         "qs_pg:id":318348,
         "unlc:id":"KH-7",
         "wd:id":"Q748470",
         "wk:page":"Kampot Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ecd8b5381d4ad298798cb6126097c22e",
+    "wof:geomhash":"8afd77c5f4b581aa0ff2592cddcdfa5a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938098,
+    "wof:lastmodified":1695884484,
     "wof:name":"K\u00e2mp\u00f4t",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/730/99/85673099.geojson
+++ b/data/856/730/99/85673099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012239,
-    "geom:area_square_m":148790558.72628,
+    "geom:area_square_m":148790913.556629,
     "geom:bbox":"104.263856,10.445389,104.425959,10.587746",
     "geom:latitude":10.522827,
     "geom:longitude":104.345812,
@@ -291,16 +291,18 @@
         "gn:id":1830937,
         "gp:id":20070094,
         "hasc:id":"KH.KB",
+        "iso:code":"KH-23",
         "iso:id":"KH-23",
         "qs_pg:id":1121150,
         "wd:id":"Q852089",
         "wk:page":"Kep Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9189590ac2345a7cecd36067a59b9d5",
+    "wof:geomhash":"00a2ef21b9f9d6f9f400ef2544c03d08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938101,
+    "wof:lastmodified":1695884875,
     "wof:name":"Kep",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/01/85673101.geojson
+++ b/data/856/731/01/85673101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134501,
-    "geom:area_square_m":1634239456.799724,
+    "geom:area_square_m":1634239032.010967,
     "geom:bbox":"103.126198,10.274583,103.968293,10.950396",
     "geom:latitude":10.695868,
     "geom:longitude":103.720863,
@@ -313,17 +313,19 @@
         "gn:id":1899262,
         "gp:id":20070096,
         "hasc:id":"KH.KA",
+        "iso:code":"KH-18",
         "iso:id":"KH-18",
         "qs_pg:id":424303,
         "unlc:id":"KH-18",
         "wd:id":"Q220966",
         "wk:page":"Sihanoukville (city)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4aa6a3774707c9b4be22a91fb9dea20a",
+    "wof:geomhash":"83092a87074540e56659a88bcdfbd0d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938104,
+    "wof:lastmodified":1695884875,
     "wof:name":"Krong Preah Sihanouk",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/05/85673105.geojson
+++ b/data/856/731/05/85673105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236862,
-    "geom:area_square_m":2873486158.593634,
+    "geom:area_square_m":2873486358.018273,
     "geom:bbox":"105.580698,10.790262,106.206263,11.602052",
     "geom:latitude":11.156339,
     "geom:longitude":105.862876,
@@ -304,16 +304,18 @@
         "gn:id":1821992,
         "gp:id":2344943,
         "hasc:id":"KH.SR",
+        "iso:code":"KH-20",
         "iso:id":"KH-20",
         "qs_pg:id":219522,
         "wd:id":"Q751864",
         "wk:page":"Svay Rieng Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"33cbd776657a82807010c768be8243ca",
+    "wof:geomhash":"f9da7245b29a0d467cbf0aa07493fe34",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938104,
+    "wof:lastmodified":1695884875,
     "wof:name":"Svay Rieng",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/856/731/07/85673107.geojson
+++ b/data/856/731/07/85673107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288246,
-    "geom:area_square_m":3499424053.763896,
+    "geom:area_square_m":3499423802.72989,
     "geom:bbox":"104.409774,10.517929,105.098419,11.353003",
     "geom:latitude":10.940183,
     "geom:longitude":104.817103,
@@ -303,16 +303,18 @@
         "gn:id":1821939,
         "gp:id":2344944,
         "hasc:id":"KH.TA",
+        "iso:code":"KH-21",
         "iso:id":"KH-21",
         "qs_pg:id":1168628,
         "wd:id":"Q613345",
         "wk:page":"Tak\u00e9o Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c582a58e152660bc7becebd2445b534",
+    "wof:geomhash":"ed4ee306cd1ad25ce1c014b6875fb71d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "khm"
     ],
-    "wof:lastmodified":1690938104,
+    "wof:lastmodified":1695884486,
     "wof:name":"Tak\u00eav",
     "wof:parent_id":85632359,
     "wof:placetype":"region",

--- a/data/890/440/787/890440787.geojson
+++ b/data/890/440/787/890440787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055834,
-    "geom:area_square_m":675644047.49789,
+    "geom:area_square_m":675644047.497929,
     "geom:bbox":"104.412725306,11.7339537619,104.733276792,12.0504219748",
     "geom:latitude":11.868195,
     "geom:longitude":104.555711,
@@ -103,12 +103,13 @@
         "wd:id":"Q7409232",
         "wk:page":"Smach Mean Chey District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KH",
     "wof:created":1469052297,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"231368c41f883bc2931f9bd2772630e7",
+    "wof:geomhash":"8219ea2dabbdb00b269e65980e0ec2cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":890440787,
-    "wof:lastmodified":1582346020,
+    "wof:lastmodified":1695886787,
     "wof:name":"Sameakki Mean Chey",
     "wof:parent_id":85673047,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.